### PR TITLE
Fix failing tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 
 # FVM
 .fvm/
+
 # IntelliJ related
 *.iml
 *.ipr
@@ -77,3 +78,6 @@ build/
 !**/ios/**/default.mode2v3
 !**/ios/**/default.pbxuser
 !**/ios/**/default.perspectivev3
+
+# Generated files
+test/mocks.mocks.dart

--- a/lib/models/customer.dart
+++ b/lib/models/customer.dart
@@ -1,4 +1,4 @@
-/// This is teh class which contains all customer info.
+/// This is the class which contains all customer info.
 class PapercupsCustomer {
   /// Date of Customer creation.
   DateTime? createdAt;

--- a/lib/utils/getConversationDetails.dart
+++ b/lib/utils/getConversationDetails.dart
@@ -45,7 +45,7 @@ Future<Conversation> getConversationDetails(
     );
     sc(conv);
   } catch (e) {
-    conv = conversation;
+    throw (e);
   }
   client.close();
   return conv;

--- a/lib/utils/getCustomerDetails.dart
+++ b/lib/utils/getCustomerDetails.dart
@@ -59,8 +59,8 @@ Future<PapercupsCustomer> getCustomerDetails(
       phone: data["phone"],
     );
   } catch (e) {
-    c = null;
+    throw (e);
   }
   client.close();
-  return c!;
+  return c;
 }

--- a/lib/utils/getCustomerDetailsFromMetadata.dart
+++ b/lib/utils/getCustomerDetailsFromMetadata.dart
@@ -42,13 +42,12 @@ Future<PapercupsCustomer> getCustomerDetailsFromMetadata(
       updatedAt: c == null ? null : c.updatedAt,
     );
   } catch (e) {
-    // Customer will be null if there is an error.
-    c = null;
+    throw (e);
   }
   // Function to set the client.
   sc(c);
   // Closing HTTP client.
   client.close();
   // Returns customer.
-  return c!;
+  return c;
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -42,7 +42,42 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.3"
+    version: "2.0.0"
+  build_config:
+    dependency: transitive
+    description:
+      name: build_config
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.7"
+  build_daemon:
+    dependency: transitive
+    description:
+      name: build_daemon
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.10"
+  build_resolvers:
+    dependency: transitive
+    description:
+      name: build_resolvers
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
+  build_runner:
+    dependency: "direct dev"
+    description:
+      name: build_runner
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.12.2"
+  build_runner_core:
+    dependency: transitive
+    description:
+      name: build_runner_core
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.1.12"
   built_collection:
     dependency: transitive
     description:
@@ -71,6 +106,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
+  checked_yaml:
+    dependency: transitive
+    description:
+      name: checked_yaml
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   cli_util:
     dependency: transitive
     description:
@@ -172,6 +214,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  graphs:
+    dependency: transitive
+    description:
+      name: graphs
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   http:
     dependency: "direct main"
     description:
@@ -179,6 +228,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.13.0"
+  http_multi_server:
+    dependency: transitive
+    description:
+      name: http_multi_server
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0"
   http_parser:
     dependency: transitive
     description:
@@ -193,6 +249,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.17.0"
+  io:
+    dependency: transitive
+    description:
+      name: io
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.3"
+  json_annotation:
+    dependency: transitive
+    description:
+      name: json_annotation
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.1"
   logging:
     dependency: transitive
     description:
@@ -221,13 +298,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   mockito:
     dependency: "direct dev"
     description:
       name: mockito
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.1"
+    version: "5.0.2"
   package_config:
     dependency: transitive
     description:
@@ -256,6 +340,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.5.0"
+  pool:
+    dependency: transitive
+    description:
+      name: pool
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.5.0"
   pub_semver:
     dependency: transitive
     description:
@@ -263,6 +354,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  pubspec_parse:
+    dependency: transitive
+    description:
+      name: pubspec_parse
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   quiver:
     dependency: transitive
     description:
@@ -277,6 +375,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.26.0"
+  shelf:
+    dependency: transitive
+    description:
+      name: shelf
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
+  shelf_web_socket:
+    dependency: transitive
+    description:
+      name: shelf_web_socket
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -288,7 +400,7 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.10+3"
+    version: "0.9.10+4"
   source_span:
     dependency: transitive
     description:
@@ -310,6 +422,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  stream_transform:
+    dependency: transitive
+    description:
+      name: stream_transform
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   string_scanner:
     dependency: transitive
     description:
@@ -338,6 +457,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
+  timing:
+    dependency: transitive
+    description:
+      name: timing
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,5 +20,6 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^5.0.1
+  build_runner: ^1.12.2
 
 flutter:

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -1,12 +1,9 @@
 // define a call method for Sc so that Sc can be
 // mocked as a function.
-import 'package:mockito/mockito.dart';
+import 'package:mockito/annotations.dart';
 import 'package:http/http.dart' as http;
 
+@GenerateMocks([Sc, http.Client])
 abstract class Sc {
   void call(Object conv);
 }
-
-class MockClient extends Mock implements http.Client {}
-
-class MockSc extends Mock implements Sc {}

--- a/test/papercups_flutter_test.dart
+++ b/test/papercups_flutter_test.dart
@@ -10,7 +10,7 @@ import 'package:papercups_flutter/utils/utils.dart';
 
 import 'package:flutter_test/flutter_test.dart';
 
-import 'mocks.dart';
+import 'mocks.mocks.dart';
 
 void main() {
   final props = Props(
@@ -182,12 +182,13 @@ void main() {
           body: anyNamed('body'),
         ),
       ).thenAnswer((_) async => http.Response(res, 200));
+      when(client.close()).thenReturn(null);
 
       final details = await getConversationDetails(
         props,
         Conversation(),
         customer,
-        sc as Function,
+        sc,
         client: client,
       );
 
@@ -205,34 +206,22 @@ void main() {
       expect(details.accountId, equals(conv.accountId));
     });
 
-    test("returns null when there's an error", () async {
+    test("throws an exception when there's an error", () async {
       final client = MockClient();
+
       when(
         client.post(
           Uri.parse('https://${props.baseUrl}/api/conversations'),
           headers: anyNamed('headers'),
           body: anyNamed('body'),
         ),
-      ).thenThrow(HttpException('Request failed'));
+      ).thenAnswer((_) => throw (HttpException('Request failed')));
 
-      final details = await getConversationDetails(
-        props,
-        Conversation(),
-        customer,
-        () => {},
-        client: client,
+      expect(
+        getConversationDetails(props, Conversation(), customer, () => {},
+            client: client),
+        throwsException,
       );
-
-      verify(
-        client.post(
-          Uri.parse('https://${props.baseUrl}/api/conversations'),
-          headers: anyNamed('headers'),
-          body: anyNamed('body'),
-        ),
-      ).called(1);
-      verify(client.close()).called(1);
-
-      expect(details, equals(null));
     });
   });
 
@@ -261,11 +250,12 @@ void main() {
           body: anyNamed('body'),
         ),
       ).thenAnswer((_) async => http.Response(res, 200));
+      when(client.close()).thenReturn(null);
 
       final PapercupsCustomer c = await getCustomerDetails(
         props,
         customer,
-        sc as Function?,
+        sc,
         client: client,
       );
 
@@ -282,8 +272,9 @@ void main() {
       expect(c.lastSeen, equals(customer.lastSeen));
     });
 
-    test("returns null when there's an error", () async {
+    test("throws an exception when there's an error", () async {
       final client = MockClient();
+
       when(
         client.post(
           Uri.parse('https://${props.baseUrl}/api/customers'),
@@ -292,23 +283,10 @@ void main() {
         ),
       ).thenThrow(HttpException('Request failed'));
 
-      final PapercupsCustomer c = await getCustomerDetails(
-        props,
-        customer,
-        () => {},
-        client: client,
+      expect(
+        getCustomerDetails(props, customer, () => {}, client: client),
+        throwsException,
       );
-
-      verify(
-        client.post(
-          Uri.parse('https://${props.baseUrl}/api/customers'),
-          headers: anyNamed('headers'),
-          body: anyNamed('body'),
-        ),
-      ).called(1);
-      verify(client.close()).called(1);
-
-      expect(c, equals(null));
     });
   });
 
@@ -342,11 +320,12 @@ void main() {
           ),
         ),
       ).thenAnswer((_) async => http.Response(res, 200));
+      when(client.close()).thenReturn(null);
 
       final PapercupsCustomer c = await getCustomerDetailsFromMetadata(
         props,
         customer,
-        sc as Function,
+        sc,
         client: client,
       );
 
@@ -369,9 +348,10 @@ void main() {
       expect(c.lastSeen, equals(customer.lastSeen));
     });
 
-    test("returns null when there's an error", () async {
+    test("throws an exception when there's an error", () async {
       final client = MockClient();
       final sc = MockSc();
+
       when(
         client.get(
           Uri.https(
@@ -385,29 +365,9 @@ void main() {
         ),
       ).thenThrow(HttpException('Request failed'));
 
-      final PapercupsCustomer c = await getCustomerDetailsFromMetadata(
-        props,
-        customer,
-        sc as Function,
-        client: client,
-      );
-
-      verify(
-        client.get(
-          Uri.https(
-            props.baseUrl,
-            "/api/customers/identify",
-            {
-              "external_id": customer.externalId,
-              "account_id": props.accountId,
-            },
-          ),
-        ),
-      ).called(1);
-      verify(client.close()).called(1);
-      verify(sc(c)).called(1);
-
-      expect(c, equals(null));
+      expect(
+          getCustomerDetailsFromMetadata(props, customer, sc, client: client),
+          throwsException);
     });
   });
 
@@ -456,6 +416,7 @@ void main() {
           headers: anyNamed('headers'),
         ),
       ).thenAnswer((_) async => http.Response(res, 200));
+      when(client.close()).thenReturn(null);
 
       final cm = await getPastCustomerMessages(
         props,
@@ -491,6 +452,7 @@ void main() {
           headers: anyNamed('headers'),
         ),
       ).thenThrow(HttpException('Request failed'));
+      when(client.close()).thenReturn(null);
 
       await getPastCustomerMessages(
         props,

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -8,7 +8,7 @@ import 'package:http/http.dart' as http;
 
 import 'package:papercups_flutter/utils/updateUserMetadata.dart';
 
-import 'mocks.dart';
+import 'mocks.mocks.dart';
 
 void main() {
   final customer = PapercupsCustomer(
@@ -51,10 +51,10 @@ void main() {
           body: anyNamed('body'),
         ),
       ).thenAnswer((_) async => http.Response(res, 200));
+      when(client.close()).thenReturn(null);
 
-      final PapercupsCustomer c =
-          await (updateUserMetadata(props, customer.id, client: client)
-              as Future<PapercupsCustomer>);
+      final PapercupsCustomer? c =
+          await (updateUserMetadata(props, customer.id, client: client));
 
       verify(
         client.put(
@@ -66,7 +66,7 @@ void main() {
       verify(client.close()).called(1);
 
       expect(c, isNot(null));
-      expect(c.id, equals(customer.id));
+      expect(c?.id, equals(customer.id));
     });
 
     test("returns null when there's an error", () async {
@@ -78,6 +78,7 @@ void main() {
           body: anyNamed('body'),
         ),
       ).thenThrow(HttpException('Request failed'));
+      when(client.close()).thenReturn(null);
 
       final PapercupsCustomer? c =
           await updateUserMetadata(props, customer.id, client: client);


### PR DESCRIPTION
This PR fixes failing tests caused by upgrading Mockito to null safety. Mockito now recommends
using code gen to generate mocks. To that effect, `build_runner: 1.12.2` has been added to the project.

To build the code it is now necessary to first run

`flutter packages pub run build_runner build`

Also modifies some methods to throw an exception in their catch block instead of returning null. Returning null is inconvenient because of null safe code.