### PR TITLE
Fix CustomerMetadata otherMetadata not being saved

### DIFF
--- a/lib/models/classes.dart
+++ b/lib/models/classes.dart
@@ -16,7 +16,7 @@ class CustomerMetadata {
   String? externalId;
 
   /// Any extra data you want to pass can be passed as a key-value pair.
-  Map<String, String>? otherMetadata;
+  Map<String, dynamic>? otherMetadata;
 
   //Class definition.
   CustomerMetadata({
@@ -33,8 +33,7 @@ class CustomerMetadata {
         "name": this.name,
         "email": this.email,
         "external_id": this.externalId,
-        // This will spread the custom metadata
-        ...metadata,
+        "metadata": metadata,
       },
     );
   }


### PR DESCRIPTION
Hey @aguilaair!

This fixes #76 based on https://github.com/papercups-io/papercups/pull/1000#issuecomment-1122855148.

It seems that my guess here https://github.com/papercups-io/papercups_flutter/issues/76#issuecomment-1008827556 was partially right, actually.

I did test those changes locally and am indeed able to send a `Map<String, String>` as `CustomerMetadata`'s `otherMetadata` and see it appear in the Papercups dashboard:

```dart
CustomerMetadata(
  name: user.name,
  externalId: user.id,
  otherMetadata: customerMetadata.toMap(),
),
```

👇 

<img width="360" alt="Screenshot 2022-05-11 at 08 26 32" src="https://user-images.githubusercontent.com/8975443/167782773-c909b25b-c298-4e12-8db0-f840fcd8a83b.png">

