### PR TITLE
Implement theming `PapercupStyle()`, Flutter 3.0 support and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Integration with your app requires just a few lines of code, add the following w
 ```Dart
 import 'package:papercups_flutter/papercups_flutter.dart';
 
-PaperCupsWidget(
-  props: Props(
+PapercupsWidget(
+  props: PapercupsProps(
     accountId: "xxxxxxxx-xxxxxxx-xxxx-xxxxxx", //Your account id goes here.
   ),
 ),
@@ -31,57 +31,382 @@ That should get you up and running in just a few seconds ⚡️.
 
 ## Configuration
 
-### Available `PaperCupsWidget` arguments
-| Parameter | Type | Value | Default |
-| :--- | :--- | :----- | :------ |
-| **`dateLocale`** | `String` |Locale for the date, use the locales from the `intl` package.| `"en-US"` |
-| **`floatingSendMessage`** | `bool` | Wether to have the message box floating.| `false` |
-| **`props`** | `Props` | **Required**, here is where all of the config for the chat is contained.| N/A |
-| **`timeagoLocale`** | `dynamic` | Check [`timeago` messages](https://github.com/andresaraujo/timeago.dart/tree/master/timeago/lib/src/messages) for the available classes.| N/A |
+### Available `PapercupsWidget` arguments
+| Parameter           | Type      | Value                                                                                                                                    | Default   |
+| :------------------ | :-------- | :--------------------------------------------------------------------------------------------------------------------------------------- | :-------- |
+| **`props`**         | `Props`   | **Required**. This is where all of the config for the chat is contained.                                                                 | N/A       |
+| **`dateLocale`**    | `String`  | Locale for the date, use the locales from the `intl` package.                                                                            | `"en-US"` |
+| **`timeagoLocale`** | `dynamic` | Check [`timeago` messages](https://github.com/andresaraujo/timeago.dart/tree/master/timeago/lib/src/messages) for the available classes. | N/A       |
 
 
-### Available `Props` parameters
-| Prop | Type | Value | Default |
-| :--- | :--- | :----- | :------ |
-| **`accountId`** | `String` | **Required**, your Papercups account token | N/A |
-| **`baseUrl`** | `String` | The base URL of your API if you're self-hosting Papercups. Ensure you do not include the protocol (https) of a trailing dash (/) | app.papercups.io |
-| **`customer`** | `CustomerMetadata` | Identifying information for the customer, including `name`, `email`, `external_id`, and `metadata` (for any custom fields) | N/A |
-| **`primaryColor`** | `Color` | The theme color of your chat widget | `Theme.of(context).primaryColor` without alpha |
-| **`primaryGradient`** | `Gradient` | Gradient to specify, should be used instead of primaryColor, **DO NOT USE BOTH** | N/A |
-| **`requireEmailUpfront`** | `boolean` | If you want to require unidentified customers to provide their email before they can message you | `false` |
-| **`translations`** | `PapercupsIntl` | If you want to override the default `EN` translations displayed by the widget | `PapercupsIntl()` |
+### Available `PapercupsProps` parameters
+| Prop                      | Type                              | Value                                                                                                                             | Default              |
+| :------------------------ | :-------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------- | :------------------- |
+| **`accountId`**           | `String`                          | **Required**. Your Papercups account token.                                                                                       | N/A                  |
+| **`baseUrl`**             | `String`                          | The base URL of your API if you're self-hosting Papercups. Ensure you do not include the protocol (https) of a trailing dash (/). | `"app.papercups.io"` |
+| **`customer`**            | `PapercupsCustomerMetadata`       | Identifying information for the customer, including `name`, `email`, `externalId`, and `otherMetadata` (for any custom fields).   | N/A                  |
+| **`closeIcon`**           | `Widget`                          | The close button displayed in the header section.                                                                                 | N/A                  |
+| **`closeAction`**         | `VoidCallback`                    | The function to handle closing the widget. If not null, close button will be shown.                                               | N/A                  |
+| **`scrollEnabled`**       | `bool`                            | Whether or not to allow scrolling.                                                                                                | `true`               |
+| **`floatingSendMessage`** | `bool`                            | Wether to have the message box floating.                                                                                          | `false`              |
+| **`requireEmailUpfront`** | `bool`                            | If you want to require unidentified customers to provide their email before they can message you. Not recommended for apps.       | `false`              |
+| **`sendIcon`**            | `Widget`                          | Message send icon in the chat text field.                                                                                         | N/A                  |
+| **`onMessageBubbleTap`**  | `void Function(PapercupsMessage)` | Function to handle message bubble tap action.                                                                                     | N/A                  |
+| **`style`**               | `PapercupsStyle`                  | Class used to customize the widget appearance.                                                                                    | `PapercupsStyle()`   |
+| **`translations`**        | `PapercupsIntl`                   | If you want to override the default `EN` translations displayed by the widget.                                                    | `PapercupsIntl()`    |
 
-### Available `CustomerMetaData` parameters
-| Parameters | Type | Value | Default |
-| :--- | :--- | :----- | :------ |
-| **`email`** | `String` | The customer's email| N/A |
-| **`externalId`** | `String` | The customer's external ID | N/A |
-| **`name`** | `String` | The customer's name | N/A |
-| **`otherMetadata`** | `Map<String, String>` | Extra metadata to pass such as OS info | N/A |
+### Available `PapercupsCustomerMetadata` parameters
+| Parameters          | Type                   | Value                                                     | Default |
+| :------------------ | :--------------------- | :-------------------------------------------------------- | :------ |
+| **`email`**         | `String`               | The customer's email                                      | N/A     |
+| **`externalId`**    | `String`               | The customer's external ID                                | N/A     |
+| **`name`**          | `String`               | The customer's name                                       | N/A     |
+| **`otherMetadata`** | `Map<String, dynamic>` | Extra metadata to pass such as OS info, app version, etc. | N/A     |
+
+### Available `PapercupsStyle` parameters
+<table>
+    <tr>
+        <td>Parameters</td>
+        <td>Type</td>
+        <td>Value</td>
+        <td>Default</td>
+    </tr>
+    <tr>
+        <td><b><code>primaryColor</code></b></td>
+        <td><code>Color</code></td>
+        <td>The theme color of the chat widget.</td>
+        <td>Papercups blue:<pre lang="dart">Color(0xFF1890FF)</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>primaryGradient</code></b></td>
+        <td><code>Gradient</code></td>
+        <td>Gradient to specify, should be used instead of <code>primaryColor</code>. <b>DO NOT USE BOTH!</b></td>
+        <td>N/A</td>
+    </tr>
+    <tr>
+        <td><b><code>backgroundColor</code></b></td>
+        <td><code>Color</code></td>
+        <td>Color used in the background of the entire widget.</td>
+        <td><pre lang="dart">Theme.of(context).canvasColor</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>titleStyle</code></b></td>
+        <td><code>TextStyle</code></td>
+        <td>The text style of the title at the top of the chat widget.</td>
+        <td><pre lang="dart">TextStyle(
+  color: Colors.white,
+  fontSize: 21,
+  fontWeight: FontWeight.w600,
+)</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>titleAlign</code></b></td>
+        <td><code>TextAlign</code></td>
+        <td>The widget title alignment.</td>
+        <td><pre lang="dart">TextAlign.left</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>subtitleStyle</code></b></td>
+        <td><code>TextStyle</code></td>
+        <td>The chat widget sub title text style.</td>
+        <td><pre lang="dart">TextStyle(
+  color: props.style.titleStyle?.color?.withOpacity(0.8),
+)</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>headerHeight</code></b></td>
+        <td><code>double</code></td>
+        <td>The chat widget header height.</td>
+        <td>N/A</td>
+    </tr>
+    <tr>
+        <td><b><code>headerPadding</code></b></td>
+        <td><code>EdgeInsetsGeometry</code></td>
+        <td>The chat widget header padding.</td>
+        <td><pre lang="dart">EdgeInsets.only(
+  top: 16,
+  right: 20,
+  left: 20,
+  bottom: 12,
+)</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>noConnectionIcon</code></b></td>
+        <td><code>Widget</code></td>
+        <td>The widget displayed in the chat when there's no Internet connection.</td>
+        <td><pre lang="dart">Icon(
+  Icons.wifi_off_rounded,
+  size: 100,
+  color: Colors.grey,
+)</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>noConnectionTextStyle</code></b></td>
+        <td><code>TextStyle</code></td>
+        <td>The text style of the text displayed in the chat widget when there's no Internet connection.</td>
+        <td><pre lang="dart">Theme.of(context).textTheme.headline5?.copyWith(color: code.grey)</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>requireEmailUpfrontInputDecoration</code></b></td>
+        <td><code>InputDecoration</code></td>
+        <td>The input decoration of the require email text field.</td>
+        <td><pre lang="dart">InputDecoration(
+  border: UnderlineInputBorder(
+    borderSide: BorderSide(
+      color: Theme.of(context).dividerColor,
+      width: 0.5,
+      style: BorderStyle.solid,
+    ),
+  ),
+  enabledBorder: UnderlineInputBorder(
+    borderSide: BorderSide(
+      color: Theme.of(context).dividerColor,
+      width: 0.5,
+      style: BorderStyle.solid,
+    ),
+  ),
+  focusedBorder: UnderlineInputBorder(
+    borderSide: BorderSide(
+      color: Theme.of(context).dividerColor,
+      width: 0.5,
+      style: BorderStyle.solid,
+    ),
+  ),
+  hintText: widget.props.translations.enterEmailPlaceholder,
+  hintStyle: widget.props.style.requireEmailUpfrontInputHintStyle,
+),</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>requireEmailUpfrontKeyboardAppearance</code></b></td>
+        <td><code>Brightness</code></td>
+        <td>The keyboard brightness of the require email text field.</td>
+        <td><pre lang="dart">Brightness.light</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>requireEmailUpfrontInputHintStyle</code></b></td>
+        <td><code>TextStyle</code></td>
+        <td>The text style of the require email text field hint.</td>
+        <td><pre lang="dart">TextStyle(fontSize: 14)</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>requireEmailUpfrontInputTextStyle</code></b></td>
+        <td><code>TextStyle</code></td>
+        <td>The text style of the require email text field.</td>
+        <td>N/A</td>
+    </tr>
+    <tr>
+        <td><b><code>floatingSendMessageBoxDecoration</code></b></td>
+        <td><code>BoxDecoration</code></td>
+        <td>The box decoration of the message text field when <code>floatingSendMessage</code> prop is <code>true</code>.</td>
+        <td><pre lang="dart">BoxDecoration(
+  borderRadius: BorderRadius.circular(10),
+  boxShadow: [
+    BoxShadow(
+      blurRadius: 10,
+      color: Theme.of(context).brightness == Brightness.light
+          ? Colors.grey.withOpacity(0.4)
+          : Colors.black.withOpacity(0.8),
+    ),
+  ],
+)<pre></td>
+    </tr>
+    <tr>
+        <td><b><code>sendMessageBoxDecoration</code></b></td>
+        <td><code>BoxDecoration</code></td>
+        <td>The box decoration of the message text field.</td>
+        <td><pre lang="dart">BoxDecoration(
+  color: Theme.of(context).cardColor,
+  border: widget.showDivider
+      ? Border(
+          top: BorderSide(color: Theme.of(context).dividerColor),
+        )
+      : null,
+  boxShadow: [
+    BoxShadow(
+      blurRadius: 30,
+      color: Theme.of(context).shadowColor.withOpacity(0.1),
+    )
+  ],
+)</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>sendMessageKeyboardAppearance</code></b></td>
+        <td><code>Brightness</code></td>
+        <td>The keyboard brightness of the send message text field.</td>
+        <td><pre lang="dart">Brightness.light</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>sendMessagePlaceholderInputDecoration</code></b></td>
+        <td><code>InputDecoration</code></td>
+        <td>The input decoration of the message text field.</td>
+        <td><pre lang="dart">InputDecoration(
+  border: InputBorder.none,
+  hintText: widget.props.translations.newMessagePlaceholder,
+  hintStyle: widget.props.style.sendMessagePlaceholderTextStyle,
+)</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>sendMessagePlaceholderTextStyle</code></b></td>
+        <td><code>TextStyle</code></td>
+        <td>The text style of the message text field input hint text.</td>
+        <td><pre lang="dart">TextStyle(fontSize: 14)</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>sendMessageInputTextStyle</code></b></td>
+        <td><code>TextStyle</code></td>
+        <td>The text style of the message text field input.</td>
+        <td>N/A</td>
+    </tr>
+    <tr>
+        <td><b><code>botBubbleBoxDecoration</code></b></td>
+        <td><code>BoxDecoration</code></td>
+        <td>The box decoration of the bot chat bubbles.</td>
+        <td><pre lang="dart">BoxDecoration(
+  color: Theme.of(context).brightness == Brightness.light
+    ? brighten(Theme.of(context).disabledColor, 80)
+    : const Color(0xff282828,
+  ),
+  borderRadius: BorderRadius.circular(4),
+  )</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>botBubbleTextStyle</code></b></td>
+        <td><code>TextStyle</code></td>
+        <td>The text style of the bot chat bubbles.</td>
+        <td><pre lang="dart">TextStyle(
+  color: Theme.of(context).textTheme.bodyText1?.color,
+)</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>botAttachmentBoxDecoration</code></b></td>
+        <td><code>BoxDecoration</code></td>
+        <td>The box decoration of the bot attachment (images, files) chat bubbles.</td>
+        <td><pre lang="dart">BoxDecoration(
+  borderRadius: BorderRadius.circular(5),
+  color: Theme.of(context).brightness == Brightness.light
+    ? brighten(Theme.of(context).disabledColor, 70)
+    : Color(0xff282828,
+  ),
+)</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>botAttachmentTextStyle</code></b></td>
+        <td><code>TextStyle</code></td>
+        <td>The text style of the bot attachments file name.</td>
+        <td><pre lang="dart">TextStyle(
+  color: Theme.of(context).textTheme.bodyText1?.color,
+)</pre></td>
+    </tr>
+     <tr>
+        <td><b><code>botBubbleUsernameTextStyle</code></b></td>
+        <td><code>TextStyle</code></td>
+        <td>The text style of bot user name displayed below its chat bubbles.</td>
+        <td><pre lang="dart">TextStyle(
+  color: Theme.of(context).textTheme.bodyText1?.color?.withOpacity(0.5),
+  fontSize: 14,
+)</pre></td>
+    </tr>
+        <tr>
+        <td><b><code>userBubbleBoxDecoration</code></b></td>
+        <td><code>BoxDecoration</code></td>
+        <td>The box decoration of the user chat bubbles.</td>
+        <td><pre lang="dart">BoxDecoration(
+  color: widget.props.style.primaryColor,
+  gradient: widget.props.style.primaryGradient,
+  borderRadius: BorderRadius.circular(4),
+)</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>userBubbleTextStyle</code></b></td>
+        <td><code>TextStyle</code></td>
+        <td>The text style of the user chat bubbles.</td>
+        <td><pre lang="dart">TextStyle(color: widget.textColor)</pre><i>Depending on the luminance of the provided <code>primaryColor</code>, <code>textColor</code> can be either <code>Colors.black</code> or <code>Colors.white</code>.</i></td>
+    </tr>
+    <tr>
+        <td><b><code>userAttachmentBoxDecoration</code></b></td>
+        <td><code>BoxDecoration</code></td>
+        <td>The box decoration of the user attachment (images, files) chat bubbles.</td>
+        <td><pre lang="dart">BoxDecoration(
+  borderRadius: BorderRadius.circular(5),
+  color: darken(widget.props.style.primaryColor!, 20),
+)</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>userAttachmentTextStyle</code></b></td>
+        <td><code>TextStyle</code></td>
+        <td>The text style of the user attachments file name.</td>
+        <td><pre lang="dart">TextStyle(color: widget.textColor)</pre><i>Depending on the luminance of the provided <code>primaryColor</code>, <code>textColor</code> can be either <code>Colors.black</code> or <code>Colors.white</code>.</i></td>
+    </tr>
+    <tr>
+        <td><b><code>userBubbleSentAtTextStyle</code></b></td>
+        <td><code>TextStyle</code></td>
+        <td>The text style of the <i>"Sent x ago"</i> (or <i>"Sending..."</i>) text displayed below the latest user chat bubble.</td>
+        <td><pre lang="dart">TextStyle(color: Colors.grey)</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>chatBubbleTimeTextStyle</code></b></td>
+        <td><code>TextStyle</code></td>
+        <td>The text style of the time stamp displayed (on tap) next to the any chat bubble.</td>
+        <td><pre lang="dart">TextStyle(
+  color: Theme.of(context).textTheme.bodyText1?.color?.withAlpha(100),
+  fontSize: 10,
+)</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>chatBubbleFullDateTextStyle</code></b></td>
+        <td><code>TextStyle</code></td>
+        <td>The text style of the date displayed centered in the chat before the chat bubbles of a given day.</td>
+        <td><pre lang="dart">TextStyle(color: Colors.grey)</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>chatUploadingAlertTextStyle</code></b></td>
+        <td><code>TextStyle</code></td>
+        <td>The text style of the alert shown when an attachment is being uploaded.</td>
+        <td><pre lang="dart">Theme.of(context).textTheme.bodyText2</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>chatUploadingAlertBackgroundColor</code></b></td>
+        <td><code>Color</code></td>
+        <td>The background color of the alert shown when an attachment is being uploaded.</td>
+        <td><pre lang="dart">Theme.of(context).bottomAppBarColor</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>chatUploadErrorAlertTextStyle</code></b></td>
+        <td><code>TextStyle</code></td>
+        <td>The text style of the error alert shown when an attachment failed to upload.</td>
+        <td><pre lang="dart">Theme.of(context).textTheme.bodyText2</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>chatUploadErrorAlertBackgroundColor</code></b></td>
+        <td><code>Color</code></td>
+        <td>The background color of the error alert shown when an attachment failed to upload.</td>
+        <td><pre lang="dart">Theme.of(context).bottomAppBarColor</pre></td>
+    </tr>
+</table>
 
 ### Available `PapercupsIntl` parameters
-| Parameters | Type | Value | Default |
-| :--- | :--- | :----- | :------ |
-| **`attachmentNamePlaceholder`** | `String` | Text displayed when an attachment doesn't have a file name | `"No Name"` |
-| **`attachmentUploadErrorText`** | `String` | Error message displayed when an attachment could not be uploaded | `"Failed to upload attachment"` |
-| **`attachmentUploadedText`** | `String` | Text displayed when an attachment has been uploaded | `"Attachment uploaded"` |
-| **`attachmentUploadingText`** | `String` | Text displayed when an attachment is been uploaded | `"Uploading..."` |
-| **`companyName`** | `String` | Company name to show on greeting | `"Bot"` |
-| **`enterEmailPlaceholder`** | `String` | This is the placeholder text in the email input section | `"Enter your email"` |
-| **`fileText`** | `String` | Text displayed on the tile where the user decides to upload a file | `"File"` |
-| **`greeting`** | `String` | An optional initial message to greet your customers with | N/A |
-| **`historyFetchErrorText`** | `String` | Error message displayed when the customer history couldn't be fetched | `"There was an issue retrieving your details. Please try again!` |
-| **`imageText`** | `String` | Text displayed on the tile where the user decides to upload an image | `"Image` |
-| **`loadingText`** | `String` | Text displayed when the chat is loading | `"Loading..."` |
-| **`newMessagePlaceholder`** | `String` | The placeholder text in the new message input | `"Start typing..."` |
-| **`noConnectionText`** | `String` | The placeholder text in the new message input | `"No Connection"` |
-| **`retryButtonLabel`** | `String` | Label used in the retry button when the chat history couldn't be fetched | `"Retry"` |
-| **`sendingText`** | `String` | Text to show while message is sending | `"Sending..."` |
-| **`sentText`** | `String` | Text to show when the message is sent | `"Sent"` |
-| **`subtitle`** | `String` | The subtitle in the header of your chat widget | `"How can we help you?"` |
-| **`textCopiedText`** | `String` | Text displayed when a text has been copied after long press on a chat bubble | `"Text copied to clipboard"` |
-| **`title`** | `String` | The title in the header of your chat widget | `"Welcome!"` |
-| **`uploadedText`** | `String` | Text displayed after the percentage value of an attachment being uploaded | `"uploaded"` |
+| Parameters                      | Type     | Value                                                                        | Default                                                           |
+| :------------------------------ | :------- | :--------------------------------------------------------------------------- | :---------------------------------------------------------------- |
+| **`attachmentNamePlaceholder`** | `String` | Text displayed when an attachment doesn't have a file name                   | `"No Name"`                                                       |
+| **`attachmentUploadErrorText`** | `String` | Error message displayed when an attachment could not be uploaded             | `"Failed to upload attachment"`                                   |
+| **`attachmentUploadedText`**    | `String` | Text displayed when an attachment has been uploaded                          | `"Attachment uploaded"`                                           |
+| **`attachmentUploadingText`**   | `String` | Text displayed when an attachment is been uploaded                           | `"Uploading..."`                                                  |
+| **`companyName`**               | `String` | Company name to show on greeting                                             | `"Bot"`                                                           |
+| **`enterEmailPlaceholder`**     | `String` | This is the placeholder text in the email input section                      | `"Enter your email"`                                              |
+| **`fileText`**                  | `String` | Text displayed on the tile where the user decides to upload a file           | `"File"`                                                          |
+| **`greeting`**                  | `String` | An optional initial message to greet your customers with                     | N/A                                                               |
+| **`historyFetchErrorText`**     | `String` | Error message displayed when the customer history couldn't be fetched        | `"There was an issue retrieving your details. Please try again!"` |
+| **`imageText`**                 | `String` | Text displayed on the tile where the user decides to upload an image         | `"Image"`                                                         |
+| **`loadingText`**               | `String` | Text displayed when the chat is loading                                      | `"Loading..."`                                                    |
+| **`newMessagePlaceholder`**     | `String` | The placeholder text in the new message input                                | `"Start typing..."`                                               |
+| **`noConnectionText`**          | `String` | The placeholder text in the new message input                                | `"No Connection"`                                                 |
+| **`retryButtonLabel`**          | `String` | Label used in the retry button when the chat history couldn't be fetched     | `"Retry"`                                                         |
+| **`sendingText`**               | `String` | Text to show while message is sending                                        | `"Sending..."`                                                    |
+| **`sentText`**                  | `String` | Text to show when the message is sent                                        | `"Sent"`                                                          |
+| **`subtitle`**                  | `String` | The subtitle in the header of your chat widget                               | `"How can we help you?"`                                          |
+| **`textCopiedText`**            | `String` | Text displayed when a text has been copied after long press on a chat bubble | `"Text copied to clipboard"`                                      |
+| **`title`**                     | `String` | The title in the header of your chat widget                                  | `"Welcome!"`                                                      |
+| **`uploadedText`**              | `String` | Text displayed after the percentage value of an attachment being uploaded    | `"uploaded"`                                                      |
 
 
 ## Supporters

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ That should get you up and running in just a few seconds ⚡️.
 ### Available `PapercupsWidget` arguments
 | Parameter           | Type      | Value                                                                                                                                    | Default   |
 | :------------------ | :-------- | :--------------------------------------------------------------------------------------------------------------------------------------- | :-------- |
-| **`props`**         | `Props`   | **Required**. This is where all of the config for the chat is contained.                                                                 | N/A       |
+| **`props`**         | `PapercupsProps`   | **Required**. This is where all of the config for the chat is contained.                                                                 | N/A       |
 | **`dateLocale`**    | `String`  | Locale for the date, use the locales from the `intl` package.                                                                            | `"en-US"` |
 | **`timeagoLocale`** | `dynamic` | Check [`timeago` messages](https://github.com/andresaraujo/timeago.dart/tree/master/timeago/lib/src/messages) for the available classes. | N/A       |
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -41,10 +41,8 @@ class _MyHomePageState extends State<MyHomePage> {
   var show = true;
   var elevated = false;
 
-  TextEditingController titleController =
-      TextEditingController(text: "Welcome to Papercups!");
-  TextEditingController subtitleController =
-      TextEditingController(text: "Ask us anything using the chat window!");
+  TextEditingController titleController = TextEditingController(text: "Welcome to Papercups!");
+  TextEditingController subtitleController = TextEditingController(text: "Ask us anything using the chat window!");
   Color color = Color(0xff1890ff);
 
   @override
@@ -117,8 +115,7 @@ class _MyHomePageState extends State<MyHomePage> {
                         ElevatedButton.icon(
                           icon: Icon(Icons.code_rounded),
                           onPressed: () {
-                            launch(
-                                "https://github.com/papercups-io/papercups_flutter");
+                            launch("https://github.com/papercups-io/papercups_flutter");
                           },
                           label: Text("View the code"),
                         ),
@@ -129,19 +126,16 @@ class _MyHomePageState extends State<MyHomePage> {
                             color: Color(0xff1890ff),
                           ),
                           onPressed: () {
-                            launch(
-                                "https://pub.dev/packages/papercups_flutter");
+                            launch("https://pub.dev/packages/papercups_flutter");
                           },
                           label: Text(
                             "View the Package",
                             style: TextStyle(color: Colors.black),
                           ),
                           style: ButtonStyle(
-                            backgroundColor:
-                                MaterialStateProperty.resolveWith<Color>(
+                            backgroundColor: MaterialStateProperty.resolveWith<Color>(
                               (Set<MaterialState> states) {
-                                return Colors
-                                    .white; // Use the component's default.
+                                return Colors.white; // Use the component's default.
                               },
                             ),
                           ),
@@ -151,8 +145,7 @@ class _MyHomePageState extends State<MyHomePage> {
                     SizedBox(
                       height: 20,
                     ),
-                    Text(
-                        "Hello! Try customizing the chat widget's display text and colors."),
+                    Text("Hello! Try customizing the chat widget's display text and colors."),
                     Divider(
                       height: 20,
                     ),
@@ -170,8 +163,7 @@ class _MyHomePageState extends State<MyHomePage> {
                             ThemeModeSelector(
                                 height: 25,
                                 onChanged: (mode) {
-                                  ThemeModeManager.of(context)!.themeMode =
-                                      mode;
+                                  ThemeModeManager.of(context)!.themeMode = mode;
                                 }),
                           ],
                         ),
@@ -209,11 +201,9 @@ class _MyHomePageState extends State<MyHomePage> {
                           hintText: 'Enter a title',
                           contentPadding: EdgeInsets.all(10),
                           isCollapsed: true,
-                          border: const OutlineInputBorder(
-                              borderRadius: BorderRadius.zero),
+                          border: const OutlineInputBorder(borderRadius: BorderRadius.zero),
                           focusedBorder: OutlineInputBorder(
-                              borderSide: BorderSide(color: Color(0xff1890ff)),
-                              borderRadius: BorderRadius.zero),
+                              borderSide: BorderSide(color: Color(0xff1890ff)), borderRadius: BorderRadius.zero),
                         ),
                       ),
                     ),
@@ -245,8 +235,7 @@ class _MyHomePageState extends State<MyHomePage> {
                     SizedBox(
                       height: 40,
                     ),
-                    Text(
-                        "Try changing the color (you can enter any value you want!)"),
+                    Text("Try changing the color (you can enter any value you want!)"),
                     SizedBox(
                       height: 15,
                     ),
@@ -297,22 +286,21 @@ class _MyHomePageState extends State<MyHomePage> {
                 child: ClipRRect(
                   borderRadius: BorderRadius.circular(15),
                   child: PapercupsWidget(
-                    floatingSendMessage: elevated,
-                    closeAction: () {
-                      setState(() {
-                        show = !show;
-                      });
-                    },
-                    props: Props(
+                    props: PapercupsProps(
                       accountId: "843d8a14-8cbc-43c7-9dc9-3445d427ac4e",
                       translations: PapercupsIntl(
                         title: titleController.text,
                         subtitle: subtitleController.text,
-                        greeting:
-                            "Hello, have any questions or feedback? Let me know below!",
+                        greeting: "Hello, have any questions or feedback? Let me know below!",
                       ),
-                      primaryColor: color,
-                      customer: CustomerMetadata(
+                      floatingSendMessage: elevated,
+                      closeAction: () {
+                        setState(() {
+                          show = !show;
+                        });
+                      },
+                      style: PapercupsStyle(primaryColor: color),
+                      customer: PapercupsCustomerMetadata(
                         email: "admin@aguilaair.tech",
                         externalId: "123",
                       ),
@@ -334,12 +322,10 @@ class ThemeModeManager extends StatefulWidget {
   final Widget Function(ThemeMode? themeMode)? builder;
   final ThemeMode? defaultThemeMode;
 
-  const ThemeModeManager({Key? key, this.builder, this.defaultThemeMode})
-      : super(key: key);
+  const ThemeModeManager({Key? key, this.builder, this.defaultThemeMode}) : super(key: key);
 
   @override
-  _ThemeModeManagerState createState() =>
-      _ThemeModeManagerState(themeMode: defaultThemeMode);
+  _ThemeModeManagerState createState() => _ThemeModeManagerState(themeMode: defaultThemeMode);
 
   static _ThemeModeManagerState? of(BuildContext context) {
     return context.findAncestorStateOfType<_ThemeModeManagerState>();

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -296,7 +296,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 margin: EdgeInsets.all(20),
                 child: ClipRRect(
                   borderRadius: BorderRadius.circular(15),
-                  child: PaperCupsWidget(
+                  child: PapercupsWidget(
                     floatingSendMessage: elevated,
                     closeAction: () {
                       setState(() {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -70,7 +70,7 @@ packages:
       name: equatable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.3"
   fake_async:
     dependency: transitive
     description:
@@ -184,6 +184,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -204,7 +211,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.0-beta.1"
+    version: "3.0.0"
   path:
     dependency: transitive
     description:
@@ -260,7 +267,7 @@ packages:
       name: phoenix_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.0"
+    version: "0.5.3"
   platform:
     dependency: transitive
     description:
@@ -342,7 +349,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   thememode_selector:
     dependency: "direct main"
     description:

--- a/lib/models/classes.dart
+++ b/lib/models/classes.dart
@@ -89,7 +89,7 @@ class PapercupsCustomerMetadata {
   });
 
   String toJsonString() {
-    final metadata = otherMetadata != null ? otherMetadata! : {};
+    final metadata = otherMetadata ?? {};
     return json.encode(
       {
         'name': name,

--- a/lib/models/classes.dart
+++ b/lib/models/classes.dart
@@ -3,8 +3,8 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 
 /// Customer Metadata, this contains the customer's information.
-class CustomerMetadata {
-  //Declaration of variables.
+class PapercupsCustomerMetadata {
+  // Declaration of variables.
 
   /// This is the name of your user.
   String? name;
@@ -18,8 +18,8 @@ class CustomerMetadata {
   /// Any extra data you want to pass can be passed as a key-value pair.
   Map<String, dynamic>? otherMetadata;
 
-  //Class definition.
-  CustomerMetadata({
+  // Class definition.
+  const PapercupsCustomerMetadata({
     this.email,
     this.externalId,
     this.name,
@@ -138,7 +138,7 @@ class PapercupsIntl {
 }
 
 /// This contains all the possible configurations for the chat widget.
-class Props {
+class PapercupsProps {
   /// This is the top widget text style
   TextStyle? titleStyle;
 
@@ -160,8 +160,8 @@ class Props {
   /// If you are self-hosting papercups, this base URL should be changed.
   String baseUrl;
 
-  /// This is the data that you will see on your dashboard such as the email or the name of the person.
-  CustomerMetadata? customer;
+  /// This is the data that you will see on your dashboard such as the email or the name of the user.
+  final PapercupsCustomerMetadata? customer;
 
   /// This is the close button in the header section.
   Widget closeIcon;
@@ -188,7 +188,7 @@ class Props {
   PapercupsIntl translations;
 
   // Class definition.
-  Props({
+  const PapercupsProps({
     required this.accountId,
     this.baseUrl = 'app.papercups.io',
     this.translations = const PapercupsIntl(),

--- a/lib/models/classes.dart
+++ b/lib/models/classes.dart
@@ -16,7 +16,7 @@ class CustomerMetadata {
   String? externalId;
 
   /// Any extra data you want to pass can be passed as a key-value pair.
-  Map<String, String>? otherMetadata;
+  Map<String, dynamic>? otherMetadata;
 
   //Class definition.
   CustomerMetadata({
@@ -27,14 +27,13 @@ class CustomerMetadata {
   });
 
   String toJsonString() {
-    var metadata = this.otherMetadata != null ? this.otherMetadata! : {};
+    final metadata = otherMetadata != null ? otherMetadata! : {};
     return json.encode(
       {
-        "name": this.name,
-        "email": this.email,
-        "external_id": this.externalId,
-        // This will spread the custom metadata
-        ...metadata,
+        'name': name,
+        'email': email,
+        'external_id': externalId,
+        'metadata': metadata,
       },
     );
   }
@@ -113,28 +112,27 @@ class PapercupsIntl {
   //String agentUnavailableText;
 
   const PapercupsIntl({
-    this.historyFetchErrorText =
-        "There was an issue retrieving your details. Please try again!",
+    this.historyFetchErrorText = 'There was an issue retrieving your details. Please try again!',
     this.attachmentUploadErrorText = 'Failed to upload attachment',
     // this.agentUnavailableText  = "We're away at the moment.",
     this.attachmentUploadedText = 'Attachment uploaded',
-    this.textCopiedText = "Text copied to clipboard",
+    this.textCopiedText = 'Text copied to clipboard',
     this.attachmentUploadingText = 'Uploading...',
-    this.enterEmailPlaceholder = "Enter your email",
+    this.enterEmailPlaceholder = 'Enter your email',
     // this.agentAvailableText = "We're available.",
-    this.newMessagePlaceholder = "Start typing...",
-    this.noConnectionText = "No Connection",
-    this.attachmentNamePlaceholder = "No Name",
-    this.subtitle = "How can we help you?",
-    this.loadingText = "Loading...",
-    this.uploadedText = "uploaded",
-    this.retryButtonLabel = "Retry",
-    this.sendingText = "Sending...",
+    this.newMessagePlaceholder = 'Start typing...',
+    this.noConnectionText = 'No Connection',
+    this.attachmentNamePlaceholder = 'No Name',
+    this.subtitle = 'How can we help you?',
+    this.loadingText = 'Loading...',
+    this.uploadedText = 'uploaded',
+    this.retryButtonLabel = 'Retry',
+    this.sendingText = 'Sending...',
     this.imageText = 'Image',
-    this.companyName = "Bot",
+    this.companyName = 'Bot',
     this.fileText = 'File',
-    this.sentText = "Sent",
-    this.title = "Welcome!",
+    this.sentText = 'Sent',
+    this.title = 'Welcome!',
     this.greeting,
   });
 }
@@ -192,7 +190,7 @@ class Props {
   // Class definition.
   Props({
     required this.accountId,
-    this.baseUrl = "app.papercups.io",
+    this.baseUrl = 'app.papercups.io',
     this.translations = const PapercupsIntl(),
     this.customer,
     this.closeIcon = const Icon(Icons.close_rounded),

--- a/lib/models/classes.dart
+++ b/lib/models/classes.dart
@@ -1,22 +1,84 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:papercups_flutter/models/message.dart';
+
+/// This contains all the possible configurations for the chat widget.
+class PapercupsProps {
+  /// Required to create the widget, identifies the account.
+  final String accountId;
+
+  /// If you are self-hosting papercups, this base URL should be changed.
+  final String baseUrl;
+
+  /// This is the data that you will see on your dashboard such as the email or the name of the user.
+  final PapercupsCustomerMetadata? customer;
+
+  /// This is the close button displayed in the header section.
+  final Widget closeIcon;
+
+  /// Function to handle closing the widget.
+  /// If not null, close button will be shown.
+  final VoidCallback? closeAction;
+
+  /// This allows you to choose if you want to show your status.
+  // final bool showAgentAvailability;
+
+  /// Whether or not to allow scrolling.
+  final bool scrollEnabled;
+
+  /// Set to true in order to make the send message section float
+  final bool floatingSendMessage;
+
+  /// If you want to require unidentified customers to provide their email before they can message you.
+  /// Not recommended for apps.
+  final bool requireEmailUpfront;
+
+  /// Message send icon in the chat text field
+  final Widget? sendIcon;
+
+  /// Function to handle message bubble tap action.
+  final void Function(PapercupsMessage)? onMessageBubbleTap;
+
+  /// This class contains all the styling options used by the widget.
+  final PapercupsStyle style;
+
+  /// This contains all the texts that can be displayed by the widget.
+  final PapercupsIntl translations;
+
+  // Class definition.
+  const PapercupsProps({
+    required this.accountId,
+    this.baseUrl = 'app.papercups.io',
+    this.customer,
+    this.closeIcon = const Icon(Icons.close_rounded),
+    this.closeAction,
+    //this.showAgentAvailability = false,
+    this.scrollEnabled = true,
+    this.floatingSendMessage = false,
+    this.requireEmailUpfront = false,
+    this.sendIcon,
+    this.onMessageBubbleTap,
+    this.style = const PapercupsStyle(),
+    this.translations = const PapercupsIntl(),
+  });
+}
 
 /// Customer Metadata, this contains the customer's information.
 class PapercupsCustomerMetadata {
   // Declaration of variables.
 
   /// This is the name of your user.
-  String? name;
+  final String? name;
 
   /// This is the email of the user.
-  String? email;
+  final String? email;
 
   /// This is an external ID of the user.
-  String? externalId;
+  final String? externalId;
 
   /// Any extra data you want to pass can be passed as a key-value pair.
-  Map<String, dynamic>? otherMetadata;
+  final Map<String, dynamic>? otherMetadata;
 
   // Class definition.
   const PapercupsCustomerMetadata({
@@ -37,6 +99,161 @@ class PapercupsCustomerMetadata {
       },
     );
   }
+}
+
+/// This class contains all the styling options used by the widget.
+class PapercupsStyle {
+  /// Color in which the header is going to be in, if not defined will be primary color used in app.
+  final Color? primaryColor;
+
+  /// Gradient to specify, should be used instead of primaryColor, DO NOT USE BOTH.
+  final Gradient? primaryGradient;
+
+  /// Color used in the background of the entire widget.
+  final Color? backgroundColor;
+
+  /// Text style of the title at the top of the chat widget.
+  final TextStyle? titleStyle;
+
+  /// This is the top widget title alignment.
+  final TextAlign? titleAlign;
+
+  /// This is the widget sub title text style.
+  final TextStyle? subtitleStyle;
+
+  /// Widget header height.
+  final double? headerHeight;
+
+  /// Widget header padding.
+  final EdgeInsetsGeometry headerPadding;
+
+  /// Widget displayed in the widget when there's no Internet connection.
+  final Widget? noConnectionIcon;
+
+  /// Text style of the text displayed in the widget when there's no Internet connection.
+  final TextStyle? noConnectionTextStyle;
+
+  /// Input decoration of the require email text field.
+  final InputDecoration? requireEmailUpfrontInputDecoration;
+
+  /// Keyboard brightness of the require email text field
+  final Brightness? requireEmailUpfrontKeyboardAppearance;
+
+  /// Text style of the require email text field.
+  final TextStyle? requireEmailUpfrontInputTextStyle;
+
+  /// Text style of the require email text field hint.
+  final TextStyle? requireEmailUpfrontInputHintStyle;
+
+  /// Box decoration of the message text field when `floatingSendMessage` prop is `true`.
+  final BoxDecoration? floatingSendMessageBoxDecoration;
+
+  /// Box decoration of the message text field.
+  final BoxDecoration? sendMessageBoxDecoration;
+
+  /// Keyboard brightness of the send message text field.
+  final Brightness? sendMessageKeyboardAppearance;
+
+  /// Input decoration of the message text field.
+  final InputDecoration? sendMessagePlaceholderInputDecoration;
+
+  /// Text style of the message text field input hint text.
+  final TextStyle? sendMessagePlaceholderTextStyle;
+
+  /// Text style of the message text field input.
+  final TextStyle? sendMessageInputTextStyle;
+
+  /// Box decoration of the bot chat bubbles.
+  final BoxDecoration? botBubbleBoxDecoration;
+
+  /// Text style of the bot chat bubbles.
+  final TextStyle? botBubbleTextStyle;
+
+  /// Box decoration of the bot attachment (images, files) chat bubbles.
+  final BoxDecoration? botAttachmentBoxDecoration;
+
+  /// Text style of the bot attachments file name.
+  final TextStyle? botAttachmentTextStyle;
+
+  /// Text style of bot user name displayed below its chat bubbles.
+  final TextStyle? botBubbleUsernameTextStyle;
+
+  /// Box decoration of the user chat bubbles.
+  final BoxDecoration? userBubbleBoxDecoration;
+
+  /// Text style of the user chat bubbles.
+  final TextStyle? userBubbleTextStyle;
+
+  /// Box decoration of the user attachment (images, files) chat bubbles.
+  final BoxDecoration? userAttachmentBoxDecoration;
+
+  /// Text style of the user attachments file name.
+  final TextStyle? userAttachmentTextStyle;
+
+  /// Text style of the _"Sent x ago"_ (or _"Sending..."_) text displayed below the latest user chat bubble.
+  final TextStyle? userBubbleSentAtTextStyle;
+
+  /// Text style of the time stamp displayed (on tap) next to the any chat bubble.
+  final TextStyle? chatBubbleTimeTextStyle;
+
+  /// Text style of the date displayed centered in the chat before the chat bubbles of a given day.
+  final TextStyle? chatBubbleFullDateTextStyle;
+
+  /// Text style of the alert shown when an attachment is being uploaded.
+  final TextStyle? chatUploadingAlertTextStyle;
+
+  /// Background color of the alert shown when an attachment is being uploaded.
+  final Color? chatUploadingAlertBackgroundColor;
+
+  /// Text style of the error alert shown when an attachment failed to upload.
+  final TextStyle? chatUploadErrorAlertTextStyle;
+
+  /// Background color of the error alert shown when an attachment failed to upload.
+  final Color? chatUploadErrorAlertBackgroundColor;
+
+  // Class definition.
+  const PapercupsStyle({
+    this.primaryColor = const Color(0xFF1890FF),
+    this.primaryGradient,
+    this.backgroundColor,
+    this.titleStyle = const TextStyle(
+      color: Colors.white,
+      fontSize: 21,
+      fontWeight: FontWeight.w600,
+    ),
+    this.titleAlign = TextAlign.left,
+    this.subtitleStyle,
+    this.headerHeight,
+    this.headerPadding = const EdgeInsets.only(top: 16, right: 20, left: 20, bottom: 12),
+    this.noConnectionIcon,
+    this.noConnectionTextStyle,
+    this.requireEmailUpfrontInputDecoration,
+    this.requireEmailUpfrontKeyboardAppearance = Brightness.light,
+    this.requireEmailUpfrontInputHintStyle = const TextStyle(fontSize: 14),
+    this.requireEmailUpfrontInputTextStyle,
+    this.floatingSendMessageBoxDecoration,
+    this.sendMessageBoxDecoration,
+    this.sendMessageKeyboardAppearance = Brightness.light,
+    this.sendMessagePlaceholderInputDecoration,
+    this.sendMessagePlaceholderTextStyle = const TextStyle(fontSize: 14),
+    this.sendMessageInputTextStyle,
+    this.botBubbleBoxDecoration,
+    this.botBubbleTextStyle,
+    this.userBubbleBoxDecoration,
+    this.botAttachmentBoxDecoration,
+    this.botAttachmentTextStyle,
+    this.botBubbleUsernameTextStyle,
+    this.userBubbleTextStyle,
+    this.userAttachmentBoxDecoration,
+    this.userAttachmentTextStyle,
+    this.userBubbleSentAtTextStyle,
+    this.chatBubbleTimeTextStyle,
+    this.chatBubbleFullDateTextStyle,
+    this.chatUploadingAlertTextStyle,
+    this.chatUploadingAlertBackgroundColor,
+    this.chatUploadErrorAlertTextStyle,
+    this.chatUploadErrorAlertBackgroundColor,
+  });
 }
 
 /// This class contains all the text that can be displayed by the widget.
@@ -134,85 +351,5 @@ class PapercupsIntl {
     this.sentText = 'Sent',
     this.title = 'Welcome!',
     this.greeting,
-  });
-}
-
-/// This contains all the possible configurations for the chat widget.
-class PapercupsProps {
-  /// This is the top widget text style
-  TextStyle? titleStyle;
-
-  /// This is the top widget title alignment
-  TextAlign? titleAlign;
-
-  /// This is the  subtitle TextStyle
-  TextStyle? subtitleStyle;
-
-  /// Color in which the header is going to be in, if not defined will be primary color used in app.
-  Color? primaryColor;
-
-  /// Gradient to specify, should be used instead of primaryColor, DO NOT USE BOTH.
-  Gradient? primaryGradient;
-
-  /// Required to create the widget, identifies the account.
-  String accountId;
-
-  /// If you are self-hosting papercups, this base URL should be changed.
-  String baseUrl;
-
-  /// This is the data that you will see on your dashboard such as the email or the name of the user.
-  final PapercupsCustomerMetadata? customer;
-
-  /// This is the close button in the header section.
-  Widget closeIcon;
-
-  /// This allows you to choose if you want to show your status.
-  //bool showAgentAvailability;
-
-  /// This Will allow you to require an email to chat. Not recommended for an app.
-  bool requireEmailUpfront;
-
-  /// Whether to allow scrolling.
-  bool scrollEnabled;
-
-  /// Header padding.
-  EdgeInsetsGeometry headerPadding;
-
-  /// Header height.
-  double? headerHeight;
-
-  /// Message send icon for the chat section.
-  Widget? sendIcon;
-
-  /// This contains all the texts that can be displayed by the widget.
-  PapercupsIntl translations;
-
-  // Class definition.
-  const PapercupsProps({
-    required this.accountId,
-    this.baseUrl = 'app.papercups.io',
-    this.translations = const PapercupsIntl(),
-    this.customer,
-    this.closeIcon = const Icon(Icons.close_rounded),
-    this.primaryColor,
-    this.requireEmailUpfront = false,
-    this.scrollEnabled = true,
-    //this.showAgentAvailability = false,
-    this.titleStyle = const TextStyle(
-      color: Colors.white,
-      fontSize: 21,
-      fontWeight: FontWeight.w600,
-    ),
-    this.subtitleStyle,
-    this.titleAlign = TextAlign.left,
-    this.headerHeight,
-    this.headerPadding = const EdgeInsets.only(
-      top: 16,
-      right: 20,
-      left: 20,
-      bottom: 12,
-    ),
-    this.primaryGradient,
-    this.sendIcon,
   });
 }

--- a/lib/papercups_flutter.dart
+++ b/lib/papercups_flutter.dart
@@ -80,9 +80,8 @@ class _PapercupsWidgetState extends State<PapercupsWidget> {
       _socket = PhoenixSocket("wss://" + widget.props.baseUrl + '/socket/websocket')..connect();
       _subscribeToSocket();
     }
-    if (widget.props.customer != null &&
-        widget.props.customer!.externalId != null &&
-        (_customer == null || _customer!.createdAt == null) &&
+    if (widget.props.customer?.externalId != null &&
+        _customer?.createdAt == null &&
         _conversation.id == null &&
         _conversation.messages.length <= 1) {
       getCustomerHistory(
@@ -221,8 +220,7 @@ class _PapercupsWidgetState extends State<PapercupsWidget> {
                         _socket = PhoenixSocket("wss://" + widget.props.baseUrl + '/socket/websocket')..connect();
                         _subscribeToSocket();
                       }
-                      if (widget.props.customer != null &&
-                          widget.props.customer!.externalId != null &&
+                      if (widget.props.customer?.externalId != null &&
                           (_customer == null || _customer!.createdAt == null) &&
                           _conversation.id == null)
                         getCustomerHistory(

--- a/lib/papercups_flutter.dart
+++ b/lib/papercups_flutter.dart
@@ -15,7 +15,7 @@ export 'package:timeago/timeago.dart';
 /// Returns the webview which contains the chat. To use it simply call PaperCupsWidget(), making sure to add the props!
 class PapercupsWidget extends StatefulWidget {
   /// Initialize the props that you will pass on PaperCupsWidget.
-  final Props props;
+  final PapercupsProps props;
 
   /// Locale for the date, use the locales from the `intl` package.
   /// For example `"es"` or `"en-UK"`.

--- a/lib/papercups_flutter.dart
+++ b/lib/papercups_flutter.dart
@@ -190,15 +190,19 @@ class _PaperCupsWidgetState extends State<PaperCupsWidget> {
     _conversationChannel = c;
   }
 
+  /// This allows a value of type T or T?
+  /// to be treated as a value of type T?.
+  ///
+  /// We use this so that APIs that have become
+  /// non-nullable can still be used with `!` and `?`
+  /// to support older versions of the API as well.
+  T? _ambiguate<T>(T? value) => value;
+
   void rebuild(void Function() fn, {bool stateMsg = false, animate = false}) {
     _sending = stateMsg;
     if (mounted) setState(fn);
-    if (animate &&
-        mounted &&
-        _conversation.messages.isNotEmpty &&
-        WidgetsBinding.instance != null &&
-        _controller.hasClients) {
-      WidgetsBinding.instance!.addPostFrameCallback((_) {
+    if (animate && mounted && _conversation.messages.isNotEmpty && _controller.hasClients) {
+      _ambiguate(WidgetsBinding.instance)?.addPostFrameCallback((_) {
         _controller.animateTo(
           _controller.position.maxScrollExtent,
           curve: Curves.easeIn,

--- a/lib/papercups_flutter.dart
+++ b/lib/papercups_flutter.dart
@@ -13,7 +13,7 @@ export 'models/classes.dart';
 export 'package:timeago/timeago.dart';
 
 /// Returns the webview which contains the chat. To use it simply call PaperCupsWidget(), making sure to add the props!
-class PaperCupsWidget extends StatefulWidget {
+class PapercupsWidget extends StatefulWidget {
   /// Initialize the props that you will pass on PaperCupsWidget.
   final Props props;
 
@@ -26,7 +26,7 @@ class PaperCupsWidget extends StatefulWidget {
   /// for the available classes.
   final timeagoLocale;
 
-  /// If not null, close button will be shown.
+  PapercupsWidget({
   final Function? closeAction;
 
   /// Set to true in order to make the send message section float
@@ -35,7 +35,6 @@ class PaperCupsWidget extends StatefulWidget {
   /// Function to handle message bubble tap action
   final void Function(PapercupsMessage)? onMessageBubbleTap;
 
-  PaperCupsWidget({
     required this.props,
     this.dateLocale = "en-US",
     this.timeagoLocale,
@@ -45,10 +44,10 @@ class PaperCupsWidget extends StatefulWidget {
   });
 
   @override
-  _PaperCupsWidgetState createState() => _PaperCupsWidgetState();
+  _PapercupsWidgetState createState() => _PapercupsWidgetState();
 }
 
-class _PaperCupsWidgetState extends State<PaperCupsWidget> {
+class _PapercupsWidgetState extends State<PapercupsWidget> {
   bool _connected = false;
   PhoenixSocket? _socket;
   PhoenixChannel? _channel;
@@ -155,7 +154,7 @@ class _PaperCupsWidgetState extends State<PaperCupsWidget> {
   }
 
   @override
-  void didUpdateWidget(PaperCupsWidget oldWidget) {
+  void didUpdateWidget(PapercupsWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.props.primaryColor != widget.props.primaryColor) {
       if ((widget.props.primaryColor != null &&

--- a/lib/utils/apiInteraction/getConversationDetails.dart
+++ b/lib/utils/apiInteraction/getConversationDetails.dart
@@ -7,7 +7,7 @@ import '../../models/models.dart';
 /// This function will get the conversation details that we need in order to join the room.
 /// The most important detail is the ID, and this will return a **new** conversation.
 Future<Conversation> getConversationDetails(
-  Props p,
+  PapercupsProps p,
   Conversation conversation,
   PapercupsCustomer customer,
   Function sc, {

--- a/lib/utils/apiInteraction/getCustomerDetails.dart
+++ b/lib/utils/apiInteraction/getCustomerDetails.dart
@@ -18,16 +18,14 @@ Future<PapercupsCustomer> getCustomerDetails(
   }
   try {
     var timeNow = DateTime.now().toUtc().toIso8601String();
-    var metadata = p.customer != null && p.customer!.otherMetadata != null
-        ? p.customer!.otherMetadata!
-        : {};
+    var metadata = p.customer?.otherMetadata ?? {};
     var jsonString = jsonEncode(
       {
         "customer": {
           "account_id": p.accountId,
-          "name": c != null ? c.name : null,
-          "email": c != null ? c.email : null,
-          "external_id": c != null ? c.externalId : null,
+          "name": c?.name,
+          "email": c?.email,
+          "external_id": c?.externalId,
           "first_seen": timeNow,
           "last_seen_at": timeNow,
           ...metadata,
@@ -43,21 +41,13 @@ Future<PapercupsCustomer> getCustomerDetails(
     );
     var data = jsonDecode(res.body)["data"];
     c = PapercupsCustomer(
-      createdAt: data["created_at"] != null
-          ? parseDateFromUTC(data["created_at"])
-          : null,
+      createdAt: parseDateFromUTC(data["created_at"]),
       email: data["email"],
       externalId: data["external_id"],
-      firstSeen: data["first_seen"] != null
-          ? parseDateFromUTC(data["first_seen"])
-          : null,
+      firstSeen: parseDateFromUTC(data["first_seen"]),
       id: data["id"],
-      lastSeenAt: data["last_seen_at"] != null
-          ? parseDateFromUTC(data["last_seen_at"])
-          : null,
-      updatedAt: data["updated_at"] != null
-          ? parseDateFromUTC(data["updated_at"])
-          : null,
+      lastSeenAt: parseDateFromUTC(data["last_seen_at"]),
+      updatedAt: parseDateFromUTC(data["updated_at"]),
       name: data["name"],
       phone: data["phone"],
     );

--- a/lib/utils/apiInteraction/getCustomerDetails.dart
+++ b/lib/utils/apiInteraction/getCustomerDetails.dart
@@ -5,7 +5,7 @@ import '../../models/models.dart';
 import '../utils.dart';
 
 Future<PapercupsCustomer> getCustomerDetails(
-  Props p,
+  PapercupsProps p,
   PapercupsCustomer? c,
   Function? sc, {
   Client? client,

--- a/lib/utils/apiInteraction/getCustomerDetailsFromMetadata.dart
+++ b/lib/utils/apiInteraction/getCustomerDetailsFromMetadata.dart
@@ -7,7 +7,7 @@ import '../../models/models.dart';
 /// This funtction is used to get the customer details from Papercups.
 /// This is the function responsible for finding the Customer's ID.
 Future<PapercupsCustomer> getCustomerDetailsFromMetadata(
-  Props p,
+  PapercupsProps p,
   PapercupsCustomer? c,
   Function sc, {
   Client? client,

--- a/lib/utils/apiInteraction/getCustomerHistory.dart
+++ b/lib/utils/apiInteraction/getCustomerHistory.dart
@@ -12,7 +12,7 @@ import '../socket/joinConversation.dart';
 /// This function is used to get the history.
 /// It also initializes the necessary funtions if the customer is known.
 Future<bool> getCustomerHistory({
-  required Props props,
+  required PapercupsProps props,
   PapercupsCustomer? c,
   required Function setCustomer,
   List<PapercupsMessage>? messages,

--- a/lib/utils/apiInteraction/getPastCustomerMessages.dart
+++ b/lib/utils/apiInteraction/getPastCustomerMessages.dart
@@ -7,7 +7,7 @@ import '../utils.dart';
 
 /// This function is used to get the past messages from the customer.
 Future<Map<String, dynamic>> getPastCustomerMessages(
-  Props p,
+  PapercupsProps p,
   PapercupsCustomer c, {
   Client? client,
 }) async {

--- a/lib/utils/apiInteraction/getPastCustomerMessages.dart
+++ b/lib/utils/apiInteraction/getPastCustomerMessages.dart
@@ -55,12 +55,8 @@ Future<Map<String, dynamic>> getPastCustomerMessages(
                   email: val["user"]["email"],
                   id: val["user"]["id"],
                   role: val["user"]["role"],
-                  displayName: (val["user"]["display_name"] != null)
-                      ? val["user"]["display_name"]
-                      : null,
-                  profilePhotoUrl: (val["user"]["profile_photo_url"] != null)
-                      ? val["user"]["profile_photo_url"]
-                      : null,
+                  displayName: val["user"]["display_name"],
+                  profilePhotoUrl: val["user"]["profile_photo_url"],
                 )
               : null,
           attachments: (val["attachments"] != null)
@@ -74,9 +70,7 @@ Future<Map<String, dynamic>> getPastCustomerMessages(
                 }).toList()
               : null,
           fileIds: (val["attachments"] != null)
-              ? (val["attachments"] as List<dynamic>).map((attachment) {
-                  return attachment["id"] as String;
-                }).toList()
+              ? (val["attachments"] as List<dynamic>).map((attachment) => attachment["id"] as String).toList()
               : null,
         ),
       );

--- a/lib/utils/apiInteraction/updateUserMetadata.dart
+++ b/lib/utils/apiInteraction/updateUserMetadata.dart
@@ -28,21 +28,13 @@ Future<PapercupsCustomer?> updateUserMetadata(
     );
     var data = jsonDecode(res.body)["data"];
     c = PapercupsCustomer(
-      createdAt: data["created_at"] != null
-          ? parseDateFromUTC(data["created_at"])
-          : null,
+      createdAt: parseDateFromUTC(data["created_at"]),
       email: data["email"],
       externalId: data["external_id"],
-      firstSeen: data["first_seen"] != null
-          ? parseDateFromUTC(data["first_seen"])
-          : null,
+      firstSeen: parseDateFromUTC(data["first_seen"]),
       id: data["id"],
-      lastSeenAt: data["last_seen_at"] != null
-          ? parseDateFromUTC(data["last_seen_at"])
-          : null,
-      updatedAt: data["updated_at"] != null
-          ? parseDateFromUTC(data["updated_at"])
-          : null,
+      lastSeenAt: parseDateFromUTC(data["last_seen_at"]),
+      updatedAt: parseDateFromUTC(data["updated_at"]),
       name: data["name"],
       phone: data["phone"],
     );

--- a/lib/utils/apiInteraction/updateUserMetadata.dart
+++ b/lib/utils/apiInteraction/updateUserMetadata.dart
@@ -8,7 +8,7 @@ import '../utils.dart';
 
 /// This function is used to update customer details on the Papercups server.
 Future<PapercupsCustomer?> updateUserMetadata(
-  Props p,
+  PapercupsProps p,
   String? cId, {
   Client? client,
 }) async {

--- a/lib/utils/fileInteraction/handleDownloads.dart
+++ b/lib/utils/fileInteraction/handleDownloads.dart
@@ -6,15 +6,15 @@ import 'package:papercups_flutter/models/models.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:universal_io/io.dart';
 
-Future<void> handleDownloadStream(Stream<StreamedResponse> resp,
-    {required File file,
-    Function? onDownloading,
-    Function? onDownloaded}) async {
+Future<void> handleDownloadStream(
+  Stream<StreamedResponse> resp, {
+  required File file,
+  Function? onDownloading,
+  Function? onDownloaded,
+}) async {
   List<List<int>> chunks = [];
 
-  if (onDownloading != null) {
-    onDownloading();
-  }
+  onDownloading?.call();
 
   resp.listen((StreamedResponse r) {
     r.stream.listen((List<int> chunk) {

--- a/lib/utils/fileInteraction/nativeFilePicker.dart
+++ b/lib/utils/fileInteraction/nativeFilePicker.dart
@@ -3,12 +3,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:papercups_flutter/models/models.dart';
 import 'package:papercups_flutter/utils/fileInteraction/uploadFile.dart';
-import 'package:papercups_flutter/widgets/alert.dart';
+import 'package:papercups_flutter/widgets/widgets.dart';
 
 void nativeFilePicker({
   required FileType type,
   required BuildContext context,
-  required widget,
+  required SendMessage widget,
   required Function onUploadSuccess,
 }) async {
   try {
@@ -20,8 +20,8 @@ void nativeFilePicker({
       Alert.show(
         widget.props.translations.attachmentUploadingText,
         context,
-        textStyle: Theme.of(context).textTheme.bodyText2,
-        backgroundColor: Theme.of(context).bottomAppBarColor,
+        textStyle: widget.props.style.chatUploadingAlertTextStyle ?? Theme.of(context).textTheme.bodyText2,
+        backgroundColor: widget.props.style.chatUploadingAlertBackgroundColor ?? Theme.of(context).bottomAppBarColor,
         gravity: Alert.bottom,
         duration: Alert.lengthLong,
       );
@@ -32,8 +32,9 @@ void nativeFilePicker({
           Alert.show(
             "${(sentBytes * 100 / totalBytes).toStringAsFixed(2)}% ${widget.props.translations.uploadedText}",
             context,
-            textStyle: Theme.of(context).textTheme.bodyText2,
-            backgroundColor: Theme.of(context).bottomAppBarColor,
+            textStyle: widget.props.style.chatUploadingAlertTextStyle ?? Theme.of(context).textTheme.bodyText2,
+            backgroundColor:
+                widget.props.style.chatUploadingAlertBackgroundColor ?? Theme.of(context).bottomAppBarColor,
             gravity: Alert.bottom,
             duration: Alert.lengthLong,
           );
@@ -46,8 +47,8 @@ void nativeFilePicker({
     Alert.show(
       widget.props.translations.attachmentUploadErrorText,
       context,
-      textStyle: Theme.of(context).textTheme.bodyText2,
-      backgroundColor: Theme.of(context).bottomAppBarColor,
+      textStyle: widget.props.style.chatUploadErrorAlertTextStyle ?? Theme.of(context).textTheme.bodyText2,
+      backgroundColor: widget.props.style.chatUploadErrorAlertBackgroundColor ?? Theme.of(context).bottomAppBarColor,
       gravity: Alert.bottom,
       duration: Alert.lengthLong,
     );
@@ -56,8 +57,8 @@ void nativeFilePicker({
     Alert.show(
       widget.props.translations.attachmentUploadErrorText,
       context,
-      textStyle: Theme.of(context).textTheme.bodyText2,
-      backgroundColor: Theme.of(context).bottomAppBarColor,
+      textStyle: widget.props.style.chatUploadErrorAlertTextStyle ?? Theme.of(context).textTheme.bodyText2,
+      backgroundColor: widget.props.style.chatUploadErrorAlertBackgroundColor ?? Theme.of(context).bottomAppBarColor,
       gravity: Alert.bottom,
       duration: Alert.lengthLong,
     );

--- a/lib/utils/fileInteraction/nativeFilePicker.dart
+++ b/lib/utils/fileInteraction/nativeFilePicker.dart
@@ -16,7 +16,7 @@ void nativeFilePicker({
       type: type,
     ))
         ?.files;
-    if (_paths != null && _paths.first.path != null) {
+    if (_paths?.first.path != null) {
       Alert.show(
         widget.props.translations.attachmentUploadingText,
         context,
@@ -27,7 +27,7 @@ void nativeFilePicker({
       );
       List<PapercupsAttachment> attachments = await uploadFile(
         widget.props,
-        filePath: _paths.first.path,
+        filePath: _paths?.first.path,
         onUploadProgress: (sentBytes, totalBytes) {
           Alert.show(
             "${(sentBytes * 100 / totalBytes).toStringAsFixed(2)}% ${widget.props.translations.uploadedText}",

--- a/lib/utils/fileInteraction/uploadFile.dart
+++ b/lib/utils/fileInteraction/uploadFile.dart
@@ -9,7 +9,7 @@ import '../../models/models.dart';
 typedef void OnUploadProgressCallback(int sentBytes, int totalBytes);
 
 Future<List<PapercupsAttachment>> uploadFile(
-  Props p, {
+  PapercupsProps p, {
   OnUploadProgressCallback? onUploadProgress,
   String? fileName,
   Uint8List? fileBytes,

--- a/lib/utils/fileInteraction/uploadFile.dart
+++ b/lib/utils/fileInteraction/uploadFile.dart
@@ -46,9 +46,7 @@ Future<List<PapercupsAttachment>> uploadFile(
 
             byteCount += data.length;
 
-            if (onUploadProgress != null) {
-              onUploadProgress(byteCount, totalByteLength);
-            }
+            onUploadProgress?.call(byteCount, totalByteLength);
           },
           handleError: (error, stack, sink) {
             throw error;

--- a/lib/utils/fileInteraction/webFilePicker.dart
+++ b/lib/utils/fileInteraction/webFilePicker.dart
@@ -2,12 +2,12 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:papercups_flutter/models/attachment.dart';
 import 'package:papercups_flutter/utils/fileInteraction/uploadFile.dart';
-import 'package:papercups_flutter/widgets/alert.dart';
+import 'package:papercups_flutter/widgets/widgets.dart';
 
 Future<void> webFilePicker({
   required BuildContext context,
   required Function onUploadSuccess,
-  required widget,
+  required SendMessage widget,
 }) async {
   try {
     var picked = await FilePicker.platform.pickFiles();
@@ -16,8 +16,8 @@ Future<void> webFilePicker({
       Alert.show(
         widget.props.translations.attachmentUploadingText,
         context,
-        textStyle: Theme.of(context).textTheme.bodyText2,
-        backgroundColor: Theme.of(context).bottomAppBarColor,
+        textStyle: widget.props.style.chatUploadingAlertTextStyle ?? Theme.of(context).textTheme.bodyText2,
+        backgroundColor: widget.props.style.chatUploadingAlertBackgroundColor ?? Theme.of(context).bottomAppBarColor,
         gravity: Alert.bottom,
         duration: Alert.lengthLong,
       );
@@ -32,8 +32,8 @@ Future<void> webFilePicker({
     Alert.show(
       widget.props.translations.attachmentUploadErrorText,
       context,
-      textStyle: Theme.of(context).textTheme.bodyText2,
-      backgroundColor: Theme.of(context).bottomAppBarColor,
+      textStyle: widget.props.style.chatUploadErrorAlertTextStyle ?? Theme.of(context).textTheme.bodyText2,
+      backgroundColor: widget.props.style.chatUploadErrorAlertBackgroundColor ?? Theme.of(context).bottomAppBarColor,
       gravity: Alert.bottom,
       duration: Alert.lengthLong,
     );

--- a/lib/utils/fileInteraction/webFilePicker.dart
+++ b/lib/utils/fileInteraction/webFilePicker.dart
@@ -12,7 +12,7 @@ Future<void> webFilePicker({
   try {
     var picked = await FilePicker.platform.pickFiles();
 
-    if (picked != null && picked.files.first.bytes != null) {
+    if (picked?.files.first.bytes != null) {
       Alert.show(
         widget.props.translations.attachmentUploadingText,
         context,
@@ -23,7 +23,7 @@ Future<void> webFilePicker({
       );
       List<PapercupsAttachment> attachments = await uploadFile(
         widget.props,
-        fileBytes: picked.files.first.bytes,
+        fileBytes: picked!.files.first.bytes,
         fileName: picked.files.first.name,
       );
       onUploadSuccess(attachments);

--- a/lib/utils/parseDateFromUTC.dart
+++ b/lib/utils/parseDateFromUTC.dart
@@ -1,7 +1,11 @@
 /// This function converts a sting in ISO8601 format into a DateTime object which is in UTC
 /// and then converts in into the local timezone. Used to convert times from the Papercups API.
 /// It assumes all times provided are in UTC or it will force them bo be.
-DateTime? parseDateFromUTC(String time) {
+DateTime? parseDateFromUTC(String? time) {
+  if (time == null) {
+    return null;
+  }
+
   DateTime? processed;
 
   if (DateTime.tryParse(time) != null) {
@@ -12,7 +16,7 @@ DateTime? parseDateFromUTC(String time) {
     }
   }
 
-  if (processed != null) processed = processed.toLocal();
+  processed = processed?.toLocal();
 
   return processed;
 }

--- a/lib/utils/socket/intitChannels.dart
+++ b/lib/utils/socket/intitChannels.dart
@@ -8,7 +8,7 @@ initChannels(
   bool _connected,
   PhoenixSocket _socket,
   PhoenixChannel? _channel,
-  Props props,
+  PapercupsProps props,
   bool _canJoinConversation,
   Function setState,
 ) {

--- a/lib/utils/socket/joinConversation.dart
+++ b/lib/utils/socket/joinConversation.dart
@@ -43,35 +43,28 @@ PhoenixChannel? joinConversationAndListen({
                     id: event.payload!["id"],
                     attachments: (event.payload!["attachments"] != null)
                         ? (event.payload!["attachments"] as List<dynamic>)
-                            .map((attachment) {
-                            return PapercupsAttachment(
-                              contentType: attachment["content_type"],
-                              fileName: attachment["filename"],
-                              fileUrl: attachment["file_url"],
-                              id: attachment["id"],
-                            );
-                          }).toList()
+                            .map(
+                              (attachment) => PapercupsAttachment(
+                                contentType: attachment["content_type"],
+                                fileName: attachment["filename"],
+                                fileUrl: attachment["file_url"],
+                                id: attachment["id"],
+                              ),
+                            )
+                            .toList()
                         : null,
                     fileIds: (event.payload!["attachments"] != null)
                         ? (event.payload!["attachments"] as List<dynamic>)
-                            .map((attachment) {
-                            return attachment["id"] as String;
-                          }).toList()
+                            .map((attachment) => attachment["id"] as String)
+                            .toList()
                         : null,
                     user: (event.payload!["user"] != null)
                         ? User(
                             email: event.payload!["user"]["email"],
                             id: event.payload!["user"]["id"],
                             role: event.payload!["user"]["role"],
-                            displayName:
-                                (event.payload!["user"]["display_name"] != null)
-                                    ? event.payload!["user"]["display_name"]
-                                    : null,
-                            profilePhotoUrl: (event.payload!["user"]
-                                        ["profile_photo_url"] !=
-                                    null)
-                                ? event.payload!["user"]["profile_photo_url"]
-                                : null,
+                            displayName: event.payload!["user"]["display_name"],
+                            profilePhotoUrl: event.payload!["user"]["profile_photo_url"],
                           )
                         : null,
                     customer: (event.payload!["customer"] != null)
@@ -81,15 +74,9 @@ PhoenixChannel? joinConversationAndListen({
                           )
                         : null,
                     userId: event.payload!["user_id"],
-                    createdAt: event.payload!["created_at"] != null
-                        ? parseDateFromUTC(event.payload!["created_at"])
-                        : null,
-                    seenAt: event.payload!["seen_at"] != null
-                        ? parseDateFromUTC(event.payload!["seen_at"])
-                        : null,
-                    sentAt: event.payload!["sent_at"] != null
-                        ? parseDateFromUTC(event.payload!["sent_at"])
-                        : null,
+                    createdAt: parseDateFromUTC(event.payload!["created_at"]),
+                    seenAt: parseDateFromUTC(event.payload!["seen_at"]),
+                    sentAt: parseDateFromUTC(event.payload!["sent_at"]),
                   ),
                 );
               }, animate: true);

--- a/lib/widgets/chat/attachment.dart
+++ b/lib/widgets/chat/attachment.dart
@@ -21,7 +21,7 @@ class Attachment extends StatefulWidget {
       : super(key: key);
 
   final bool userSent;
-  final Props props;
+  final PapercupsProps props;
   final String fileName;
   final Color textColor;
   final bool msgHasText;

--- a/lib/widgets/chat/attachment.dart
+++ b/lib/widgets/chat/attachment.dart
@@ -81,20 +81,24 @@ class _AttachmentState extends State<Attachment> {
       },
       child: Container(
         width: double.infinity,
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(5),
-          color: widget.userSent
-              ? darken(widget.props.primaryColor!, 20)
-              : Theme.of(context).brightness == Brightness.light
-                  ? brighten(Theme.of(context).disabledColor, 70)
-                  : Color(0xff282828),
-        ),
+        decoration: widget.userSent && widget.props.style.userAttachmentBoxDecoration != null
+            ? widget.props.style.userAttachmentBoxDecoration
+            : !widget.userSent && widget.props.style.botAttachmentBoxDecoration != null
+                ? widget.props.style.botAttachmentBoxDecoration
+                : BoxDecoration(
+                    borderRadius: BorderRadius.circular(5),
+                    color: widget.userSent
+                        ? darken(widget.props.style.primaryColor!, 20)
+                        : Theme.of(context).brightness == Brightness.light
+                            ? brighten(Theme.of(context).disabledColor, 70)
+                            : Color(0xff282828),
+                  ),
         padding: EdgeInsets.symmetric(vertical: 5, horizontal: 10),
         margin: EdgeInsets.symmetric(vertical: !widget.msgHasText ? 0 : 5),
         child: Row(
           children: [
             CircleAvatar(
-              backgroundColor: widget.props.primaryColor,
+              backgroundColor: widget.props.style.primaryColor,
               child: Stack(
                 alignment: Alignment.center,
                 children: [
@@ -119,11 +123,13 @@ class _AttachmentState extends State<Attachment> {
             Expanded(
               child: Text(
                 widget.fileName,
-                style: TextStyle(
-                  color: widget.userSent
-                      ? widget.textColor
-                      : Theme.of(context).textTheme.bodyText1!.color,
-                ),
+                style: widget.userSent && widget.props.style.userAttachmentTextStyle != null
+                    ? widget.props.style.userAttachmentTextStyle
+                    : !widget.userSent && widget.props.style.botAttachmentTextStyle != null
+                        ? widget.props.style.botAttachmentTextStyle
+                        : TextStyle(
+                            color: widget.userSent ? widget.textColor : Theme.of(context).textTheme.bodyText1?.color,
+                          ),
                 overflow: TextOverflow.ellipsis,
               ),
             )

--- a/lib/widgets/chat/chat.dart
+++ b/lib/widgets/chat/chat.dart
@@ -4,7 +4,7 @@ import '../../models/models.dart';
 import 'chatMessage.dart';
 
 class ChatMessages extends StatelessWidget {
-  final Props props;
+  final PapercupsProps props;
   final List<PapercupsMessage>? messages;
   final bool sending;
   final ScrollController _controller;

--- a/lib/widgets/chat/chat.dart
+++ b/lib/widgets/chat/chat.dart
@@ -57,6 +57,7 @@ class ChatMessages extends StatelessWidget {
                 sendingText: sendingText,
                 sentText: sentText,
                 textColor: textColor,
+                onMessageBubbleTap: onMessageBubbleTap,
               );
             },
           ),

--- a/lib/widgets/chat/chatBubble.dart
+++ b/lib/widgets/chat/chatBubble.dart
@@ -64,10 +64,10 @@ class ChatBubble extends StatelessWidget {
                           radius: 16,
                           backgroundColor: Colors.transparent,
                           backgroundImage:
-                              (msg.user!.profilePhotoUrl != null) ? NetworkImage(msg.user!.profilePhotoUrl!) : null,
-                          child: (msg.user!.profilePhotoUrl != null)
+                              (msg.user?.profilePhotoUrl != null) ? NetworkImage(msg.user!.profilePhotoUrl!) : null,
+                          child: (msg.user?.profilePhotoUrl != null)
                               ? null
-                              : (msg.user != null && msg.user!.displayName == null)
+                              : (msg.user?.displayName == null)
                                   ? Text(
                                       msg.user!.email!.substring(0, 1).toUpperCase(),
                                       style: TextStyle(color: widget.textColor),

--- a/lib/widgets/chat/chatBubble.dart
+++ b/lib/widgets/chat/chatBubble.dart
@@ -42,9 +42,7 @@ class ChatBubble extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Row(
-          mainAxisAlignment:
-              userSent ? MainAxisAlignment.end : MainAxisAlignment.start,
-          mainAxisSize: MainAxisSize.max,
+          mainAxisAlignment: userSent ? MainAxisAlignment.end : MainAxisAlignment.start,
           crossAxisAlignment: CrossAxisAlignment.end,
           children: [
             if (!userSent)
@@ -52,67 +50,62 @@ class ChatBubble extends StatelessWidget {
                 padding: EdgeInsets.only(
                   right: 14,
                   left: 14,
-                  top: (isFirst) ? 15 : 4,
+                  top: isFirst ? 15 : 4,
                   bottom: 5,
                 ),
-                child: (widget.msgs!.length == 1 ||
-                        nextMsg.userId != msg.userId ||
-                        isLast)
+                child: (widget.msgs!.length == 1 || nextMsg.userId != msg.userId || isLast)
                     ? Container(
                         decoration: BoxDecoration(
-                          color: widget.props.primaryColor,
-                          gradient: widget.props.primaryGradient,
+                          color: widget.props.style.primaryColor,
+                          gradient: widget.props.style.primaryGradient,
                           shape: BoxShape.circle,
                         ),
                         child: CircleAvatar(
                           radius: 16,
                           backgroundColor: Colors.transparent,
-                          backgroundImage: (msg.user!.profilePhotoUrl != null)
-                              ? NetworkImage(msg.user!.profilePhotoUrl!)
-                              : null,
+                          backgroundImage:
+                              (msg.user!.profilePhotoUrl != null) ? NetworkImage(msg.user!.profilePhotoUrl!) : null,
                           child: (msg.user!.profilePhotoUrl != null)
                               ? null
-                              : (msg.user != null &&
-                                      msg.user!.displayName == null)
+                              : (msg.user != null && msg.user!.displayName == null)
                                   ? Text(
-                                      msg.user!.email!
-                                          .substring(0, 1)
-                                          .toUpperCase(),
+                                      msg.user!.email!.substring(0, 1).toUpperCase(),
                                       style: TextStyle(color: widget.textColor),
                                     )
                                   : Text(
-                                      msg.user!.displayName!
-                                          .substring(0, 1)
-                                          .toUpperCase(),
+                                      msg.user!.displayName!.substring(0, 1).toUpperCase(),
                                       style: TextStyle(color: widget.textColor),
                                     ),
                         ),
                       )
-                    : SizedBox(
-                        width: 32,
-                      ),
+                    : const SizedBox(width: 32),
               ),
             if (userSent)
               TimeWidget(
                 userSent: userSent,
                 msg: msg,
                 isVisible: isTimeSentVisible,
+                textStyle: widget.props.style.chatBubbleTimeTextStyle,
               ),
             Container(
-              decoration: BoxDecoration(
-                color: userSent
-                    ? widget.props.primaryColor
-                    : Theme.of(context).brightness == Brightness.light
-                        ? brighten(Theme.of(context).disabledColor, 80)
-                        : Color(0xff282828),
-                gradient: userSent ? widget.props.primaryGradient : null,
-                borderRadius: BorderRadius.circular(4),
-              ),
+              decoration: userSent && widget.props.style.userBubbleBoxDecoration != null
+                  ? widget.props.style.userBubbleBoxDecoration
+                  : !userSent && widget.props.style.botBubbleBoxDecoration != null
+                      ? widget.props.style.botBubbleBoxDecoration
+                      : BoxDecoration(
+                          color: userSent
+                              ? widget.props.style.primaryColor
+                              : Theme.of(context).brightness == Brightness.light
+                                  ? brighten(Theme.of(context).disabledColor, 80)
+                                  : const Color(0xff282828),
+                          gradient: userSent ? widget.props.style.primaryGradient : null,
+                          borderRadius: BorderRadius.circular(4),
+                        ),
               constraints: BoxConstraints(
                 maxWidth: maxWidth,
               ),
               margin: EdgeInsets.only(
-                top: (isFirst) ? 15 : 4,
+                top: isFirst ? 15 : 4,
                 bottom: 4,
                 right: userSent ? 18 : 0,
               ),
@@ -128,42 +121,35 @@ class ChatBubble extends StatelessWidget {
                       return Attachment(
                         userSent: userSent,
                         props: widget.props,
-                        fileName: e.fileName ??
-                            widget.props.translations.attachmentNamePlaceholder,
+                        fileName: e.fileName ?? widget.props.translations.attachmentNamePlaceholder,
                         textColor: widget.textColor,
-                        msgHasText:
-                            (msg.attachments!.length > 1 || msg.body != null),
+                        msgHasText: msg.attachments!.length > 1 || msg.body != null,
                         attachment: e,
                       );
                     }).toList(),
-                  if (msg.body != "null")
+                  if (msg.body != 'null')
                     MarkdownBody(
                       data: text,
                       styleSheet: MarkdownStyleSheet(
-                          blockquote:
-                              TextStyle(decoration: TextDecoration.underline),
-                          p: TextStyle(
-                            color: userSent
-                                ? widget.textColor
-                                : Theme.of(context).textTheme.bodyText1!.color,
-                          ),
+                          blockquote: const TextStyle(decoration: TextDecoration.underline),
+                          p: userSent && widget.props.style.userBubbleTextStyle != null
+                              ? widget.props.style.userBubbleTextStyle
+                              : !userSent && widget.props.style.botBubbleTextStyle != null
+                                  ? widget.props.style.botBubbleTextStyle
+                                  : TextStyle(
+                                      color: userSent ? widget.textColor : Theme.of(context).textTheme.bodyText1?.color,
+                                    ),
                           a: TextStyle(
-                            color: userSent
-                                ? Colors.white
-                                : Theme.of(context).textTheme.bodyText1!.color,
+                            color: userSent ? Colors.white : Theme.of(context).textTheme.bodyText1!.color,
                           ),
-                          blockquotePadding: EdgeInsets.only(bottom: 2),
+                          blockquotePadding: const EdgeInsets.only(bottom: 2),
                           blockquoteDecoration: BoxDecoration(
                             border: Border(
                               bottom: BorderSide(
                                 width: 1.5,
                                 color: userSent
                                     ? widget.textColor
-                                    : Theme.of(context)
-                                            .textTheme
-                                            .bodyText1!
-                                            .color ??
-                                        Colors.white,
+                                    : Theme.of(context).textTheme.bodyText1!.color ?? Colors.white,
                               ),
                             ),
                           )
@@ -182,35 +168,31 @@ class ChatBubble extends StatelessWidget {
                 userSent: userSent,
                 msg: msg,
                 isVisible: isTimeSentVisible,
+                textStyle: widget.props.style.chatBubbleTimeTextStyle,
               ),
           ],
         ),
-        if (!userSent && ((nextMsg.userId != msg.userId) || (isLast)))
+        if (!userSent && ((nextMsg.userId != msg.userId) || isLast))
           Padding(
-              padding: EdgeInsets.only(left: 16, bottom: 5, top: 4),
-              child: (msg.user!.displayName == null)
-                  ? Text(
-                      msg.user!.email!,
-                      style: TextStyle(
-                        color: Theme.of(context)
-                            .textTheme
-                            .bodyText1!
-                            .color!
-                            .withOpacity(0.5),
-                        fontSize: 14,
-                      ),
-                    )
-                  : Text(
-                      msg.user!.displayName!,
-                      style: TextStyle(
-                        color: Theme.of(context)
-                            .textTheme
-                            .bodyText1!
-                            .color!
-                            .withOpacity(0.5),
-                        fontSize: 14,
-                      ),
-                    )),
+            padding: const EdgeInsets.only(left: 16, bottom: 5, top: 4),
+            child: (msg.user!.displayName == null)
+                ? Text(
+                    msg.user!.email!,
+                    style: widget.props.style.botBubbleUsernameTextStyle ??
+                        TextStyle(
+                          color: Theme.of(context).textTheme.bodyText1?.color?.withOpacity(0.5),
+                          fontSize: 14,
+                        ),
+                  )
+                : Text(
+                    msg.user!.displayName!,
+                    style: widget.props.style.botBubbleUsernameTextStyle ??
+                        TextStyle(
+                          color: Theme.of(context).textTheme.bodyText1?.color?.withOpacity(0.5),
+                          fontSize: 14,
+                        ),
+                  ),
+          ),
         if (userSent && isLast)
           Container(
             width: double.infinity,
@@ -220,29 +202,27 @@ class ChatBubble extends StatelessWidget {
               right: 18,
             ),
             child: Text(
-              widget.sending
-                  ? widget.sendingText
-                  : "${widget.sentText} ${timeago.format(msg.createdAt!)}",
+              widget.sending ? widget.sendingText : '${widget.sentText} ${timeago.format(msg.createdAt!)}',
               textAlign: TextAlign.end,
-              style: TextStyle(color: Colors.grey),
+              style: widget.props.style.userBubbleSentAtTextStyle ?? const TextStyle(color: Colors.grey),
             ),
           ),
         if (isLast || nextMsg.userId != msg.userId)
-          SizedBox(
+          const SizedBox(
             height: 10,
           ),
         if (longDay != null)
           IgnorePointer(
-            ignoring: true,
             child: Container(
-              margin: EdgeInsets.all(15),
+              margin: const EdgeInsets.all(15),
               width: double.infinity,
               child: Text(
                 longDay!,
                 textAlign: TextAlign.center,
-                style: TextStyle(
-                  color: Colors.grey,
-                ),
+                style: widget.props.style.chatBubbleFullDateTextStyle ??
+                    TextStyle(
+                      color: Colors.grey,
+                    ),
               ),
             ),
           ),

--- a/lib/widgets/chat/chatMessage.dart
+++ b/lib/widgets/chat/chatMessage.dart
@@ -28,7 +28,7 @@ class ChatMessage extends StatefulWidget {
 
   final List<PapercupsMessage>? msgs;
   final int index;
-  final Props props;
+  final PapercupsProps props;
   final bool sending;
   final double maxWidth;
   final String locale;

--- a/lib/widgets/chat/chatMessage.dart
+++ b/lib/widgets/chat/chatMessage.dart
@@ -53,7 +53,7 @@ class _ChatMessageState extends State<ChatMessage> {
 
   @override
   void dispose() {
-    if (timer != null) timer!.cancel();
+    timer?.cancel();
     super.dispose();
   }
 
@@ -89,9 +89,7 @@ class _ChatMessageState extends State<ChatMessage> {
     var isLast = widget.index == widget.msgs!.length - 1;
     var isFirst = widget.index == 0;
 
-    if (!isLast &&
-        (nextMsg.sentAt!.day != msg.sentAt!.day) &&
-        longDay == null) {
+    if (!isLast && (nextMsg.sentAt!.day != msg.sentAt!.day) && longDay == null) {
       try {
         longDay = DateFormat.yMMMMd(widget.locale).format(nextMsg.sentAt!);
       } catch (e) {
@@ -112,10 +110,8 @@ class _ChatMessageState extends State<ChatMessage> {
     if (!isLast && timer != null) timer!.cancel();
     return GestureDetector(
       onTap: () async {
-        setState(() {
-          isTimeSentVisible = true;
-        });
-        if (widget.onMessageBubbleTap != null) widget.onMessageBubbleTap!(msg);
+        setState(() => isTimeSentVisible = true);
+        widget.onMessageBubbleTap?.call(msg);
       },
       onLongPress: () {
         HapticFeedback.vibrate();

--- a/lib/widgets/chat/timeWidget.dart
+++ b/lib/widgets/chat/timeWidget.dart
@@ -7,11 +7,13 @@ class TimeWidget extends StatelessWidget {
     required this.userSent,
     required this.msg,
     required this.isVisible,
+    this.textStyle,
   }) : super(key: key);
 
   final bool userSent;
   final PapercupsMessage msg;
   final bool isVisible;
+  final TextStyle? textStyle;
 
   @override
   Widget build(BuildContext context) {
@@ -23,10 +25,11 @@ class TimeWidget extends StatelessWidget {
         padding: EdgeInsets.only(bottom: 5.0, left: 4, right: 4),
         child: Text(
           TimeOfDay.fromDateTime(msg.createdAt!).format(context),
-          style: TextStyle(
-            color: Theme.of(context).textTheme.bodyText1!.color!.withAlpha(100),
-            fontSize: 10,
-          ),
+          style: textStyle ??
+              TextStyle(
+                color: Theme.of(context).textTheme.bodyText1?.color?.withAlpha(100),
+                fontSize: 10,
+              ),
         ),
       ),
     );

--- a/lib/widgets/header/agentAvailability.dart
+++ b/lib/widgets/header/agentAvailability.dart
@@ -3,7 +3,7 @@ import '../../models/models.dart';
 import '../../utils/utils.dart';
 
 class AgentAvailability extends StatelessWidget {
-  final Props props;
+  final PapercupsProps props;
   AgentAvailability(this.props);
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/header/agentAvailability.dart
+++ b/lib/widgets/header/agentAvailability.dart
@@ -15,12 +15,12 @@ class AgentAvailability extends StatelessWidget {
       width: double.infinity,
       decoration: BoxDecoration(
         color: brighten(
-          props.primaryColor!,
+          props.style.primaryColor!,
           30,
         ),
         border: Border(
           top: BorderSide(
-            color: brighten(props.primaryColor!, 50),
+            color: brighten(props.style.primaryColor!, 50),
           ),
         ),
         boxShadow: [

--- a/lib/widgets/header/header.dart
+++ b/lib/widgets/header/header.dart
@@ -11,7 +11,7 @@ class Header extends StatelessWidget {
     this.closeAction,
   }) : super(key: key);
 
-  final Props props;
+  final PapercupsProps props;
   final Function? closeAction;
 
   @override

--- a/lib/widgets/header/header.dart
+++ b/lib/widgets/header/header.dart
@@ -12,23 +12,20 @@ class Header extends StatelessWidget {
   }) : super(key: key);
 
   final PapercupsProps props;
-  final Function? closeAction;
+  final VoidCallback? closeAction;
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: props.headerPadding,
+      padding: props.style.headerPadding,
       width: double.infinity,
-      height: props.headerHeight,
-      decoration: BoxDecoration(
-          color: props.primaryColor,
-          gradient: props.primaryGradient,
-          boxShadow: [
-            BoxShadow(
-              blurRadius: 5,
-              color: Theme.of(context).shadowColor.withOpacity(0.4),
-            )
-          ]),
+      height: props.style.headerHeight,
+      decoration: BoxDecoration(color: props.style.primaryColor, gradient: props.style.primaryGradient, boxShadow: [
+        BoxShadow(
+          blurRadius: 5,
+          color: Theme.of(context).shadowColor.withOpacity(0.4),
+        )
+      ]),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         mainAxisAlignment: MainAxisAlignment.center,
@@ -38,15 +35,14 @@ class Header extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Flexible(
-                child: Text(props.translations.title,
-                    style: props.titleStyle, textAlign: props.titleAlign),
+                child: Text(props.translations.title, style: props.style.titleStyle, textAlign: props.style.titleAlign),
               ),
               if (closeAction != null)
                 IconButton(
                   constraints: BoxConstraints(maxHeight: 21),
                   icon: props.closeIcon,
-                  onPressed: closeAction as void Function()?,
-                  color: props.titleStyle?.color,
+                  onPressed: closeAction,
+                  color: props.style.titleStyle?.color,
                   padding: EdgeInsets.zero,
                   iconSize: 21,
                   splashRadius: 20,
@@ -59,9 +55,9 @@ class Header extends StatelessWidget {
           Flexible(
             child: Text(
               props.translations.subtitle,
-              style: props.subtitleStyle ??
+              style: props.style.subtitleStyle ??
                   TextStyle(
-                    color: props.titleStyle?.color?.withOpacity(0.8),
+                    color: props.style.titleStyle?.color?.withOpacity(0.8),
                   ),
             ),
           )

--- a/lib/widgets/sendMessage/requireEmailUpfront.dart
+++ b/lib/widgets/sendMessage/requireEmailUpfront.dart
@@ -5,7 +5,7 @@ import '../../models/models.dart';
 /// Requires email upfront.
 class RequireEmailUpfront extends StatefulWidget {
   final Function setCustomer;
-  final Props props;
+  final PapercupsProps props;
   final Color textColor;
   final bool showDivider;
 

--- a/lib/widgets/sendMessage/requireEmailUpfront.dart
+++ b/lib/widgets/sendMessage/requireEmailUpfront.dart
@@ -10,7 +10,11 @@ class RequireEmailUpfront extends StatefulWidget {
   final bool showDivider;
 
   RequireEmailUpfront(
-      this.setCustomer, this.props, this.textColor, this.showDivider);
+    this.setCustomer,
+    this.props,
+    this.textColor,
+    this.showDivider,
+  );
   @override
   _RequireEmailUpfrontState createState() => _RequireEmailUpfrontState();
 }
@@ -64,40 +68,37 @@ class _RequireEmailUpfrontState extends State<RequireEmailUpfront> {
                     padding: const EdgeInsets.only(right: 15),
                     child: TextField(
                       controller: c,
-                      decoration: InputDecoration(
-                        border: UnderlineInputBorder(
-                          borderSide: new BorderSide(
-                            color: Theme.of(context).dividerColor,
-                            width: 0.5,
-                            style: BorderStyle.solid,
+                      keyboardAppearance: widget.props.style.requireEmailUpfrontKeyboardAppearance,
+                      decoration: widget.props.style.requireEmailUpfrontInputDecoration ??
+                          InputDecoration(
+                            border: UnderlineInputBorder(
+                              borderSide: BorderSide(
+                                color: Theme.of(context).dividerColor,
+                                width: 0.5,
+                                style: BorderStyle.solid,
+                              ),
+                            ),
+                            enabledBorder: UnderlineInputBorder(
+                              borderSide: BorderSide(
+                                color: Theme.of(context).dividerColor,
+                                width: 0.5,
+                                style: BorderStyle.solid,
+                              ),
+                            ),
+                            focusedBorder: UnderlineInputBorder(
+                              borderSide: BorderSide(
+                                color: Theme.of(context).dividerColor,
+                                width: 0.5,
+                                style: BorderStyle.solid,
+                              ),
+                            ),
+                            hintText: widget.props.translations.enterEmailPlaceholder,
+                            hintStyle: widget.props.style.requireEmailUpfrontInputHintStyle,
                           ),
-                        ),
-                        enabledBorder: UnderlineInputBorder(
-                          borderSide: new BorderSide(
-                            color: Theme.of(context).dividerColor,
-                            width: 0.5,
-                            style: BorderStyle.solid,
-                          ),
-                        ),
-                        focusedBorder: UnderlineInputBorder(
-                          borderSide: new BorderSide(
-                            color: Theme.of(context).dividerColor,
-                            width: 0.5,
-                            style: BorderStyle.solid,
-                          ),
-                        ),
-                        hintText:
-                            widget.props.translations.enterEmailPlaceholder,
-                        hintStyle: const TextStyle(
-                          fontSize: 14,
-                        ),
-                      ),
+                      style: widget.props.style.requireEmailUpfrontInputTextStyle,
                       onSubmitted: (val) {
                         if (hasMatch)
-                          widget.setCustomer(
-                              PapercupsCustomer(
-                                  createdAt: DateTime.now(), email: val),
-                              rebuild: true);
+                          widget.setCustomer(PapercupsCustomer(createdAt: DateTime.now(), email: val), rebuild: true);
                       },
                     ),
                   ),
@@ -109,17 +110,15 @@ class _RequireEmailUpfrontState extends State<RequireEmailUpfront> {
                   child: InkWell(
                     customBorder: CircleBorder(),
                     onTap: hasMatch
-                        ? () => widget.setCustomer(
-                            PapercupsCustomer(
-                                createdAt: DateTime.now(), email: c.value.text),
+                        ? () => widget.setCustomer(PapercupsCustomer(createdAt: DateTime.now(), email: c.value.text),
                             rebuild: true)
                         : null,
                     child: Icon(
                       Icons.navigate_next_rounded,
                       color: hasMatch
-                          ? widget.props.primaryColor == null
-                              ? widget.props.primaryGradient!.colors.first
-                              : widget.props.primaryColor
+                          ? widget.props.style.primaryColor == null
+                              ? widget.props.style.primaryGradient!.colors.first
+                              : widget.props.style.primaryColor
                           : Theme.of(context).disabledColor,
                       size: 20,
                     ),
@@ -135,9 +134,7 @@ class _RequireEmailUpfrontState extends State<RequireEmailUpfront> {
                       enabled: false,
                       border: InputBorder.none,
                       hintText: widget.props.translations.newMessagePlaceholder,
-                      hintStyle: const TextStyle(
-                        fontSize: 14,
-                      ),
+                      hintStyle: widget.props.style.sendMessagePlaceholderTextStyle,
                     ),
                   ),
                 ),

--- a/lib/widgets/sendMessage/sendMessage.dart
+++ b/lib/widgets/sendMessage/sendMessage.dart
@@ -31,7 +31,7 @@ class SendMessage extends StatefulWidget {
     this.showDivider = true,
   }) : super(key: key);
 
-  final Props props;
+  final PapercupsProps props;
   final PapercupsCustomer? customer;
   final Function? setCustomer;
   final Function? setState;
@@ -252,7 +252,7 @@ void _sendMessage(
   FocusNode fn,
   TextEditingController tc,
   PapercupsCustomer? cu,
-  Props p,
+  PapercupsProps p,
   Function? setCust,
   Conversation? conv,
   Function? setConv,

--- a/lib/widgets/sendMessage/sendMessage.dart
+++ b/lib/widgets/sendMessage/sendMessage.dart
@@ -103,8 +103,8 @@ class _SendMessageState extends State<SendMessage> {
       Alert.show(
         widget.props.translations.attachmentUploadedText,
         context,
-        textStyle: Theme.of(context).textTheme.bodyText2,
-        backgroundColor: Theme.of(context).bottomAppBarColor,
+        textStyle: widget.props.style.chatUploadingAlertTextStyle ?? Theme.of(context).textTheme.bodyText2,
+        backgroundColor: widget.props.style.chatUploadingAlertBackgroundColor ?? Theme.of(context).bottomAppBarColor,
         gravity: Alert.bottom,
         duration: Alert.lengthLong,
       );
@@ -129,11 +129,7 @@ class _SendMessageState extends State<SendMessage> {
           widget: widget,
         ),
       );
-    } else if (Platform.isAndroid ||
-        Platform.isIOS ||
-        Platform.isWindows ||
-        Platform.isLinux ||
-        Platform.isMacOS) {
+    } else if (Platform.isAndroid || Platform.isIOS || Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
       return PopupMenuButton<FileType>(
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(5)),
         icon: Transform.rotate(
@@ -154,7 +150,7 @@ class _SendMessageState extends State<SendMessage> {
             value: FileType.any,
             child: ListTile(
               leading: CircleAvatar(
-                backgroundColor: widget.props.primaryColor,
+                backgroundColor: widget.props.style.primaryColor,
                 foregroundColor: widget.textColor,
                 child: Icon(Icons.insert_drive_file_outlined),
               ),
@@ -166,7 +162,7 @@ class _SendMessageState extends State<SendMessage> {
             value: FileType.image,
             child: ListTile(
               leading: CircleAvatar(
-                backgroundColor: widget.props.primaryColor,
+                backgroundColor: widget.props.style.primaryColor,
                 foregroundColor: widget.textColor,
                 child: Icon(Icons.image_outlined),
               ),
@@ -188,33 +184,35 @@ class _SendMessageState extends State<SendMessage> {
       constraints: BoxConstraints(
         minHeight: 55,
       ),
-      decoration: BoxDecoration(
-          color: Theme.of(context).cardColor,
-          border: widget.showDivider
-              ? Border(
-                  top: BorderSide(
-                    color: Theme.of(context).dividerColor,
-                  ),
-                )
-              : null,
-          boxShadow: [
-            BoxShadow(
+      decoration: widget.props.style.sendMessageBoxDecoration ??
+          BoxDecoration(
+            color: Theme.of(context).cardColor,
+            border: widget.showDivider
+                ? Border(
+                    top: BorderSide(color: Theme.of(context).dividerColor),
+                  )
+                : null,
+            boxShadow: [
+              BoxShadow(
                 blurRadius: 30,
-                color: Theme.of(context).shadowColor.withOpacity(0.1))
-          ]),
+                color: Theme.of(context).shadowColor.withOpacity(0.1),
+              )
+            ],
+          ),
       child: Padding(
         padding: const EdgeInsets.only(left: 15, right: 0),
         child: Row(
           children: [
             Expanded(
               child: TextField(
-                decoration: InputDecoration(
-                  border: InputBorder.none,
-                  hintText: widget.props.translations.newMessagePlaceholder,
-                  hintStyle: const TextStyle(
-                    fontSize: 14,
-                  ),
-                ),
+                keyboardAppearance: widget.props.style.sendMessageKeyboardAppearance,
+                style: widget.props.style.sendMessageInputTextStyle,
+                decoration: widget.props.style.sendMessagePlaceholderInputDecoration ??
+                    InputDecoration(
+                      border: InputBorder.none,
+                      hintText: widget.props.translations.newMessagePlaceholder,
+                      hintStyle: widget.props.style.sendMessagePlaceholderTextStyle,
+                    ),
                 onSubmitted: (_) => triggerSend(),
                 controller: _msgController,
                 focusNode: _msgFocusNode,
@@ -229,8 +227,8 @@ class _SendMessageState extends State<SendMessage> {
                   width: 36,
                   margin: EdgeInsets.only(right: 8),
                   decoration: BoxDecoration(
-                    color: widget.props.primaryColor,
-                    gradient: widget.props.primaryGradient,
+                    color: widget.props.style.primaryColor,
+                    gradient: widget.props.style.primaryGradient,
                     shape: BoxShape.circle,
                   ),
                   child: widget.props.sendIcon ??
@@ -289,8 +287,7 @@ void _sendMessage(
     animate: true,
   );
 
-  if (conversationChannel == null ||
-      conversationChannel.state == PhoenixChannelState.closed) {
+  if (conversationChannel == null || conversationChannel.state == PhoenixChannelState.closed) {
     getCustomerDetails(p, cu, setCust).then(
       (customerDetails) {
         setCust!(customerDetails);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -168,7 +168,7 @@ packages:
       name: equatable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.3"
   fake_async:
     dependency: transitive
     description:
@@ -428,7 +428,7 @@ packages:
       name: phoenix_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.1+1"
+    version: "0.5.3"
   platform:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  phoenix_socket: ^0.5.0
+  phoenix_socket: ^0.5.3
   http: ">=0.12.2 <0.14.0"
   universal_io: ^2.0.4
   flutter_markdown: ">=0.5.2 <0.7.0"

--- a/test/papercups_flutter_test.dart
+++ b/test/papercups_flutter_test.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 import 'dart:io';
-import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
@@ -48,11 +47,11 @@ void main() {
       //expect(props.agentUnavailableText, null);
       expect(props.translations.companyName, "Bot");
       expect(props.translations.newMessagePlaceholder, "Start typing...");
-      expect(props.primaryColor, null);
+      expect(props.style.primaryColor, null);
       expect(props.requireEmailUpfront, false);
       expect(props.scrollEnabled, true);
       expect(props.customer, null);
-      expect(props.primaryGradient, null);
+      expect(props.style.primaryGradient, null);
       expect(props.translations.subtitle, "How can we help you?");
       expect(props.translations.title, "Welcome!");
       expect(props.translations.greeting, null);
@@ -68,7 +67,7 @@ void main() {
             //agentUnavailableText: "unavailable",
           ),
           baseUrl: "app.papercups.io",
-          primaryColor: Color(0xffffff),
+          style: PapercupsStyle(primaryColor: Color(0xffffff)),
           requireEmailUpfront: true,
           scrollEnabled: true,
           customer: PapercupsCustomerMetadata());
@@ -79,12 +78,11 @@ void main() {
       //expect(props.translations.agentUnavailableText, "unavailable");
       expect(props.translations.companyName, "name");
       expect(props.translations.newMessagePlaceholder, "placeHolder");
-      expect(props.primaryColor, Color(0xffffff));
+      expect(props.style.primaryColor, Color(0xffffff));
       expect(props.requireEmailUpfront, true);
       expect(props.scrollEnabled, true);
-      expect(props.customer!.toJsonString(),
-          '{"name":null,"email":null,"external_id":null}');
-      expect(props.primaryGradient, null);
+      expect(props.customer!.toJsonString(), '{"name":null,"email":null,"external_id":null}');
+      expect(props.style.primaryGradient, null);
       expect(props.translations.subtitle, "How can we help you?");
       expect(props.translations.title, "Welcome!");
       expect(props.translations.greeting, "greeting");
@@ -100,8 +98,7 @@ void main() {
       expect(cm.externalId, null);
       expect(cm.name, null);
       expect(cm.otherMetadata, null);
-      expect(
-          cm.toJsonString(), '{"name":null,"email":null,"external_id":null}');
+      expect(cm.toJsonString(), '{"name":null,"email":null,"external_id":null}');
     });
     test('are loaded correctly', () {
       cm = PapercupsCustomerMetadata(email: "test@test.com", externalId: "1234", name: "name", otherMetadata: {
@@ -112,8 +109,7 @@ void main() {
       expect(cm.externalId, "1234");
       expect(cm.name, "name");
       expect(cm.otherMetadata, {"Test": "string"});
-      expect(cm.toJsonString(),
-          '{"name":"name","email":"test@test.com","external_id":"1234","Test":"string"}');
+      expect(cm.toJsonString(), '{"name":"name","email":"test@test.com","external_id":"1234","Test":"string"}');
     });
   });
   group('Theming', () {
@@ -216,8 +212,7 @@ void main() {
       ).thenAnswer((_) => throw (HttpException('Request failed')));
 
       expect(
-        getConversationDetails(props, Conversation(), customer, () => {},
-            client: client),
+        getConversationDetails(props, Conversation(), customer, () => {}, client: client),
         throwsException,
       );
     });
@@ -363,9 +358,7 @@ void main() {
         ),
       ).thenThrow(HttpException('Request failed'));
 
-      expect(
-          getCustomerDetailsFromMetadata(props, customer, sc, client: client),
-          throwsException);
+      expect(getCustomerDetailsFromMetadata(props, customer, sc, client: client), throwsException);
     });
   });
 

--- a/test/papercups_flutter_test.dart
+++ b/test/papercups_flutter_test.dart
@@ -13,9 +13,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'mocks.mocks.dart';
 
 void main() {
-  final props = Props(
+  final props = PapercupsProps(
     accountId: 'account_id',
-    customer: CustomerMetadata(externalId: 'external_id'),
+    customer: PapercupsCustomerMetadata(externalId: 'external_id'),
   );
   final customer = PapercupsCustomer(
     id: 'id',
@@ -36,9 +36,9 @@ void main() {
   );
 
   group("Props", () {
-    Props props;
+    PapercupsProps props;
     test('default values', () {
-      props = Props(
+      props = PapercupsProps(
         accountId: "this-is-an-account-id",
       );
 
@@ -58,7 +58,7 @@ void main() {
       expect(props.translations.greeting, null);
     });
     test('are loaded correctly', () {
-      props = Props(
+      props = PapercupsProps(
           accountId: "this-is-an-account-id",
           translations: PapercupsIntl(
             companyName: "name",
@@ -71,7 +71,7 @@ void main() {
           primaryColor: Color(0xffffff),
           requireEmailUpfront: true,
           scrollEnabled: true,
-          customer: CustomerMetadata());
+          customer: PapercupsCustomerMetadata());
 
       expect(props.accountId, "this-is-an-account-id");
       //expect(props.translations.agentAvailableText, "test");
@@ -92,9 +92,9 @@ void main() {
   });
 
   group("Customer Metadata", () {
-    CustomerMetadata cm;
+    PapercupsCustomerMetadata cm;
     test('default values', () {
-      cm = CustomerMetadata();
+      cm = PapercupsCustomerMetadata();
 
       expect(cm.email, null);
       expect(cm.externalId, null);
@@ -104,13 +104,9 @@ void main() {
           cm.toJsonString(), '{"name":null,"email":null,"external_id":null}');
     });
     test('are loaded correctly', () {
-      cm = CustomerMetadata(
-          email: "test@test.com",
-          externalId: "1234",
-          name: "name",
-          otherMetadata: {
-            "Test": "string",
-          });
+      cm = PapercupsCustomerMetadata(email: "test@test.com", externalId: "1234", name: "name", otherMetadata: {
+        "Test": "string",
+      });
 
       expect(cm.email, "test@test.com");
       expect(cm.externalId, "1234");

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -22,9 +22,9 @@ void main() {
     name: 'name',
     phone: 'phone',
   );
-  final props = Props(
+  final props = PapercupsProps(
     accountId: 'account_id',
-    customer: CustomerMetadata(externalId: 'external_id'),
+    customer: PapercupsCustomerMetadata(externalId: 'external_id'),
   );
   group('updateUserMetadata', () {
     test('returns a customer object on success', () async {
@@ -53,8 +53,7 @@ void main() {
       ).thenAnswer((_) async => http.Response(res, 200));
       when(client.close()).thenReturn(null);
 
-      final PapercupsCustomer? c =
-          await (updateUserMetadata(props, customer.id, client: client));
+      final PapercupsCustomer? c = await (updateUserMetadata(props, customer.id, client: client));
 
       verify(
         client.put(
@@ -80,8 +79,7 @@ void main() {
       ).thenThrow(HttpException('Request failed'));
       when(client.close()).thenReturn(null);
 
-      final PapercupsCustomer? c =
-          await updateUserMetadata(props, customer.id, client: client);
+      final PapercupsCustomer? c = await updateUserMetadata(props, customer.id, client: client);
 
       verify(
         client.put(


### PR DESCRIPTION
Hi @aguilaair!

This PR includes a couple of changes listed as follow:

## Flutter 3 support

The change made in 1aa632234a7163095bacf502537427348fdfa93a fixes the redundant null-aware operators warning introduced in Flutter 3.0, while keeping [backwards compatibility](https://docs.flutter.dev/development/tools/sdk/release-notes/release-notes-3.0.0#your-code) for previous Flutter versions.

## Full theming support via new `PapercupsStyle`

Even with the work made for #18, I encountered some visual discrepancies after enabling dark mode in my app via:

```dart
MaterialApp(
  theme: Themes.lightMode, // Light mode ThemeData
  darkTheme: Themes.darkMode, // Dark mode ThemeData
)
```

That's why I exposed most of the styling params via the new `PapercupsStyle` class. The new API has been detailed in the updated README. Please feel free to double-check I didn't make any mistake there 😅.

#### ⚠️ BREAKING CHANGE

This change also required a breaking change to `PaperCupsWidget` & `Props` in order to collocate all visual params.

## Prefix all user-facing classes with `Papercups`

In order to add consistency and avoid potential naming conflicts, I add `Papercups` as a prefix to all the user-facing classes (`PapercupsCustomerMetadata`, `PapercupsProps`, `PapercupsStyle` & `PapercupsIntl`).

#### ⚠️ BREAKING CHANGE

In the same spirit, I made another breaking change which was renaming `PaperCupsWidget` to `PapercupsWidget`, so that it'd follow the official spelling.

## Update README with missing params

On top of the new `PapercupsStyle` and moving some of the old `PapercupsWidget` & `PapercupsProps` params around, I also added some existing params that were not documented yet.

---

I hope all these changes make sense to you and can fit in with what you had planned for the upcoming v3.

Let me know if you'd like me to make some changes! 🙌