### PR TITLE
Add more theming options to `PapercupsStyle()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,30 @@ That should get you up and running in just a few seconds ⚡️.
         <td>The background color of the error alert shown when an attachment failed to upload.</td>
         <td><pre lang="dart">Theme.of(context).bottomAppBarColor</pre></td>
     </tr>
+    <tr>
+        <td><b><code>chatNoConnectionAlertTextStyle</code></b></td>
+        <td><code>TextStyle</code></td>
+        <td>The text style of the alert shown when the chat is displayed but no Internet connection is available.</td>
+        <td><pre lang="dart">Theme.of(context).textTheme.bodyText2</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>chatNoConnectionAlertBackgroundColor</code></b></td>
+        <td><code>Color</code></td>
+        <td>The background color of the alert shown when the chat is displayed but no Internet connection is available.</td>
+        <td><pre lang="dart">Theme.of(context).bottomAppBarColor</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>chatCopiedTextAlertTextStyle</code></b></td>
+        <td><code>TextStyle</code></td>
+        <td>The text style of the alert shown when a chat bubble gets long pressed and its text copied.</td>
+        <td><pre lang="dart">Theme.of(context).textTheme.bodyText2</pre></td>
+    </tr>
+    <tr>
+        <td><b><code>chatCopiedTextAlertBackgroundColor</code></b></td>
+        <td><code>Color</code></td>
+        <td>The background color of the alert shown when a chat bubble gets long pressed and its text copied.</td>
+        <td><pre lang="dart">Theme.of(context).bottomAppBarColor</pre></td>
+    </tr>
 </table>
 
 ### Available `PapercupsIntl` parameters

--- a/lib/models/classes.dart
+++ b/lib/models/classes.dart
@@ -211,6 +211,18 @@ class PapercupsStyle {
   /// Background color of the error alert shown when an attachment failed to upload.
   final Color? chatUploadErrorAlertBackgroundColor;
 
+  /// Text style of the alert shown when the chat is displayed but no Internet connection is available.
+  final TextStyle? chatNoConnectionAlertTextStyle;
+
+  /// Background color of the alert shown when the chat is displayed but no Internet connection is available.
+  final Color? chatNoConnectionAlertBackgroundColor;
+
+  /// Text style of the alert shown when a chat bubble gets long pressed and its text copied.
+  final TextStyle? chatCopiedTextAlertTextStyle;
+
+  /// Background color of the alert shown when a chat bubble gets long pressed and its text copied.
+  final Color? chatCopiedTextAlertBackgroundColor;
+
   // Class definition.
   const PapercupsStyle({
     this.primaryColor = const Color(0xFF1890FF),
@@ -253,6 +265,10 @@ class PapercupsStyle {
     this.chatUploadingAlertBackgroundColor,
     this.chatUploadErrorAlertTextStyle,
     this.chatUploadErrorAlertBackgroundColor,
+    this.chatNoConnectionAlertTextStyle,
+    this.chatNoConnectionAlertBackgroundColor,
+    this.chatCopiedTextAlertTextStyle,
+    this.chatCopiedTextAlertBackgroundColor,
   });
 }
 

--- a/lib/papercups_flutter.dart
+++ b/lib/papercups_flutter.dart
@@ -98,8 +98,9 @@ class _PapercupsWidgetState extends State<PapercupsWidget> {
           Alert.show(
             widget.props.translations.historyFetchErrorText,
             context,
-            backgroundColor: Theme.of(context).bottomAppBarColor,
-            textStyle: Theme.of(context).textTheme.bodyText2,
+            textStyle: widget.props.style.chatNoConnectionAlertTextStyle ?? Theme.of(context).textTheme.bodyText2,
+            backgroundColor:
+                widget.props.style.chatNoConnectionAlertBackgroundColor ?? Theme.of(context).bottomAppBarColor,
             gravity: Alert.bottom,
             duration: Alert.lengthLong,
           );

--- a/lib/widgets/chat/chatMessage.dart
+++ b/lib/widgets/chat/chatMessage.dart
@@ -120,8 +120,8 @@ class _ChatMessageState extends State<ChatMessage> {
         Alert.show(
           widget.props.translations.textCopiedText,
           context,
-          textStyle: Theme.of(context).textTheme.bodyText2,
-          backgroundColor: Theme.of(context).bottomAppBarColor,
+          textStyle: widget.props.style.chatCopiedTextAlertTextStyle ?? Theme.of(context).textTheme.bodyText2,
+          backgroundColor: widget.props.style.chatCopiedTextAlertBackgroundColor ?? Theme.of(context).bottomAppBarColor,
           gravity: Alert.bottom,
           duration: Alert.lengthLong,
         );


### PR DESCRIPTION
Hey @aguilaair!

Quick PR to add some more params to `PapercupsStyle` that I forgot in #89:

- `chatNoConnectionAlertTextStyle`
- `chatNoConnectionAlertBackgroundColor`
- `chatCopiedTextAlertTextStyle`
- `chatCopiedTextAlertBackgroundColor`

